### PR TITLE
Fix crash on 4.1 --> coming from previous patch

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -93,7 +93,7 @@
 														<$endforeach do2$>
 														nil];
 	<$else$>
-	NSDictionary *substitutionVariables = nil;
+	NSDictionary *substitutionVariables = [NSDictionary dictionary];
 	<$endif$>
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];
@@ -146,7 +146,7 @@
 														<$endforeach do2$>
 														nil];
 	<$else$>
-	NSDictionary *substitutionVariables = nil;
+	NSDictionary *substitutionVariables = [NSDictionary dictionary];
 	<$endif$>									
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];


### PR DESCRIPTION
Hi again,

I recently sent you a patch that got accepted and went into the 1.20 release, thanks for this. This patch is now crashing on 4.1 with this error: 

**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Cannot substitute a nil substitution dictionary.'  

So here is the fix for this crash. Basically instead of passing a nil dictionary, I am now passing an empty dictionary.

Regards
Anthony
