### PR TITLE
Non-standard persistent attribute support

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -62,11 +62,13 @@
 
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
 <$foreach Attribute noninheritedAttributes do$>
+<$if Attribute.hasDefinedAttributeType$>
 - (<$Attribute.objectAttributeType$>*)primitive<$Attribute.name.initialCapitalString$>;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>*)value;
 <$if Attribute.hasScalarAttributeType$>
 - (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 <$endforeach do$>
 <$foreach Relationship noninheritedRelationships do$>


### PR DESCRIPTION
Per your request I forked the code on github for you.  It turns out after your latest build, you only had one file with major changes from my versions.  That file was templates/machine.h.motemplate which I modified to not create objects whose type is undefined.  The comment for the commit contains the name of the section and the apple URL that was the motivation for this change.
