### PR TITLE
Using keyPathsForValuesAffectingValueForKey to auto-recalculate scalar *Value properties when their parent non-scalar property changes

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -26,6 +26,17 @@
 	return (<$managedObjectClassName$>ID*)[super objectID];
 }
 
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
+	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+	<$foreach Attribute noninheritedAttributes do$><$if Attribute.hasDefinedAttributeType$><$if Attribute.hasScalarAttributeType$>
+	if ([key isEqualToString:@"<$Attribute.name$>Value"]) {
+		NSSet *affectingKey = [NSSet setWithObject:@"<$Attribute.name$>"];
+		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+	}<$endif$><$endif$><$endforeach do$>
+
+	return keyPaths;
+}
+
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
 


### PR DESCRIPTION
Hi Wolf, I'm not sure what the flow on of including this in the template would be - it could probably stand to be tidied up a little, but it saves me some work and boilerplate code - I figure it might be interesting/useful to others.
