### PR TITLE
Xmod auto-generation for versionned models

### DIFF
--- a/Xmod/Xmod.applescript
+++ b/Xmod/Xmod.applescript
@@ -22,7 +22,10 @@ on updateProjectXmod(_project)
 		repeat with modeldIt in modeldList
 			-- Find the 'active' model version
 			set currentVersionFile to full path of modeldIt & "/.xccurrentversion"
-			set activeModelVersionFilename to do shell script "/usr/libexec/PlistBuddy -c 'print _XCCurrentVersionName' " & currentVersionFile
+			tell application "System Events"
+				set currentVersionPlist to contents of property list file currentVersionFile
+				set activeModelVersionFilename to value of property list item "_XCCurrentVersionName" of currentVersionPlist
+			end tell
 			set activeModelVersion to full path of modeldIt & "/" & activeModelVersionFilename
 			set modelItr to item 1 of (every file reference of modeldIt whose name is activeModelVersionFilename)
 			-- Then update it


### PR DESCRIPTION
This pull request allows to put `xmod` tag on a versionned model _(.xcdatamodel__d__)_
Script then will automatically detect current version and call `mogenerator` on it.

This modification is non intrusive and not breaking existing behavior.
This is a popular request related to several issues : #7, #14, #37

Thanks to nvie who this is largely inspired from : nvie/mogenerator@575584320a03f8738f9e1c42f6e05f865f8aeb5a
