### PR TITLE
Add constant structs for the property names

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -4,6 +4,18 @@
 #import <CoreData/CoreData.h>
 <$if hasCustomSuperentity$>#import "<$customSuperentity$>.h"<$endif$>
 
+extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Attribute.name$>;<$endforeach do$>
+} <$managedObjectClassName$>Attributes;
+
+extern const struct <$managedObjectClassName$>Relationships {<$foreach Relationship noninheritedRelationships do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Relationship.name$>;<$endforeach do$>
+} <$managedObjectClassName$>Relationships;
+
+extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$FetchedProperty.name$>;<$endforeach do$>
+} <$managedObjectClassName$>FetchedProperties;
+
 <$foreach Relationship noninheritedRelationships do$>@class <$Relationship.destinationEntity.managedObjectClassName$>;
 <$endforeach do$>
 <$foreach Attribute noninheritedAttributes do$><$if Attribute.hasTransformableAttributeType$>@class <$Attribute.objectAttributeType$>;<$endif$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -3,6 +3,18 @@
 
 #import "_<$managedObjectClassName$>.h"
 
+const struct <$managedObjectClassName$>Attributes <$managedObjectClassName$>Attributes = {<$foreach Attribute noninheritedAttributes do$>
+	.<$Attribute.name$> = @"<$Attribute.name$>",<$endforeach do$>
+};
+
+const struct <$managedObjectClassName$>Relationships <$managedObjectClassName$>Relationships = {<$foreach Relationship noninheritedRelationships do$>
+	.<$Relationship.name$> = @"<$Relationship.name$>",<$endforeach do$>
+};
+
+const struct <$managedObjectClassName$>FetchedProperties <$managedObjectClassName$>FetchedProperties = {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+	.<$FetchedProperty.name$> = @"<$FetchedProperty.name$>",<$endforeach do$>
+};
+
 @implementation <$managedObjectClassName$>ID
 @end
 


### PR DESCRIPTION
Sampling Mike Ash's post about namespaced constants (http://www.mikeash.com/pyblog/friday-qa-2011-08-19-namespaced-constants-and-functions.html), this adds the generation of constant structs to access the attribute, relationship and fetched property names. This makes sure that when you're creating a fetch request, you can use these values to guarantee their existence.
