### PR TITLE
new template variable options

### DIFF
--- a/contributed templates/Mark Lilback/human.h.motemplate
+++ b/contributed templates/Mark Lilback/human.h.motemplate
@@ -1,0 +1,11 @@
+//
+//  <$managedObjectClassName$>.h
+//
+//  Created by <$TemplateVar.FULLUSERNAME$> on <$TemplateVar.DATE$>.
+//  Copyright (c) <$TemplateVar.YEAR$> <$TemplateVar.ORGANIZATIONNAME$>. All rights reserved.
+//
+
+#import "_<$managedObjectClassName$>.h"
+
+@interface <$managedObjectClassName$> : _<$managedObjectClassName$> {}
+@end

--- a/contributed templates/Mark Lilback/human.m.motemplate
+++ b/contributed templates/Mark Lilback/human.m.motemplate
@@ -1,0 +1,12 @@
+//
+//  <$managedObjectClassName$>.m
+//
+//  Created by <$TemplateVar.FULLUSERNAME$> on <$TemplateVar.DATE$>.
+//  Copyright (c) <$TemplateVar.YEAR$> <$TemplateVar.ORGANIZATIONNAME$>. All rights reserved.
+//
+
+#import "<$managedObjectClassName$>.h"
+
+@implementation <$managedObjectClassName$>
+
+@end

--- a/contributed templates/Mark Lilback/machine.h.motemplate
+++ b/contributed templates/Mark Lilback/machine.h.motemplate
@@ -1,0 +1,114 @@
+//
+//  _<$managedObjectClassName$>.h
+//
+//  Created by <$TemplateVar.FULLUSERNAME$> on <$TemplateVar.DATE$>.
+//  Copyright (c) <$TemplateVar.YEAR$> <$TemplateVar.ORGANIZATIONNAME$>. All rights reserved.
+//
+
+// DO NOT EDIT. This file is machine-generated and constantly overwritten.
+// Make changes to <$managedObjectClassName$>.h instead.
+
+#import <CoreData/CoreData.h>
+<$if hasCustomSuperentity$>#import "<$customSuperentity$>.h"<$endif$>
+
+extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Attribute.name$>;<$endforeach do$>
+} <$managedObjectClassName$>Attributes;
+
+extern const struct <$managedObjectClassName$>Relationships {<$foreach Relationship noninheritedRelationships do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Relationship.name$>;<$endforeach do$>
+} <$managedObjectClassName$>Relationships;
+
+extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$FetchedProperty.name$>;<$endforeach do$>
+} <$managedObjectClassName$>FetchedProperties;
+
+<$foreach Relationship noninheritedRelationships do$>@class <$Relationship.destinationEntity.managedObjectClassName$>;
+<$endforeach do$>
+<$foreach Attribute noninheritedAttributes do$><$if Attribute.hasTransformableAttributeType$>@class <$Attribute.objectAttributeType$>;<$endif$>
+<$endforeach do$>
+@interface <$managedObjectClassName$>ID : NSManagedObjectID {}
+@end
+
+@interface _<$managedObjectClassName$> : <$customSuperentity$> {}
++ (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
++ (NSString*)entityName;
++ (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
+- (<$managedObjectClassName$>ID*)objectID;
+
+<$foreach Attribute noninheritedAttributes do$>
+<$if Attribute.hasDefinedAttributeType$>
+<$if TemplateVar.arc$>
+@property (nonatomic, strong) <$Attribute.objectAttributeType$> *<$Attribute.name$>;
+<$else$>
+@property (nonatomic, retain) <$Attribute.objectAttributeType$> *<$Attribute.name$>;
+<$endif$>
+<$if Attribute.hasScalarAttributeType$>
+@property <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
+- (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
+- (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
+//- (BOOL)validate<$Attribute.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
+<$endif$>
+<$endforeach do$>
+<$foreach Relationship noninheritedRelationships do$>
+<$if Relationship.isToMany$>
+<$if TemplateVar.arc$>
+@property (nonatomic, strong) <$Relationship.immutableCollectionClassName$>* <$Relationship.name$>;
+<$else$>
+@property (nonatomic, retain) <$Relationship.immutableCollectionClassName$>* <$Relationship.name$>;
+<$endif$>
+- (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
+<$else$>
+<$if TemplateVar.arc$>
+@property (nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$>* <$Relationship.name$>;
+<$else$>
+@property (nonatomic, retain) <$Relationship.destinationEntity.managedObjectClassName$>* <$Relationship.name$>;
+<$endif$>
+//- (BOOL)validate<$Relationship.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
+<$endif$>
+<$endforeach do$>
+<$foreach FetchRequest prettyFetchRequests do$>
+<$if FetchRequest.singleResult$>
++ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
++ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
+<$else$>
++ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
++ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
+<$endif$>
+<$endforeach do$>
+<$foreach FetchedProperty noninheritedFetchedProperties do$>
+@property (nonatomic, readonly) NSArray *<$FetchedProperty.name$>;
+<$endforeach do$>
+@end
+
+@interface _<$managedObjectClassName$> (CoreDataGeneratedAccessors)
+<$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
+- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
+- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
+<$endif$><$endforeach do$>
+@end
+
+@interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
+<$foreach Attribute noninheritedAttributes do$>
+<$if Attribute.hasDefinedAttributeType$>
+- (<$Attribute.objectAttributeType$>*)primitive<$Attribute.name.initialCapitalString$>;
+- (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>*)value;
+<$if Attribute.hasScalarAttributeType$>
+- (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value;
+- (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
+<$endif$>
+<$endforeach do$>
+<$foreach Relationship noninheritedRelationships do$>
+<$if Relationship.isToMany$>
+- (<$Relationship.mutableCollectionClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
+- (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.mutableCollectionClassName$>*)value;
+<$else$>
+- (<$Relationship.destinationEntity.managedObjectClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
+- (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.destinationEntity.managedObjectClassName$>*)value;
+<$endif$>
+<$endforeach do$>
+@end

--- a/contributed templates/Mark Lilback/machine.m.motemplate
+++ b/contributed templates/Mark Lilback/machine.m.motemplate
@@ -1,0 +1,199 @@
+//
+//  _<$managedObjectClassName$>.m
+//
+//  Created by <$TemplateVar.FULLUSERNAME$> on <$TemplateVar.DATE$>.
+//  Copyright (c) <$TemplateVar.YEAR$> <$TemplateVar.ORGANIZATIONNAME$>. All rights reserved.
+//
+
+// DO NOT EDIT. This file is machine-generated and constantly overwritten.
+// Make changes to <$managedObjectClassName$>.m instead.
+
+#import "_<$managedObjectClassName$>.h"
+
+const struct <$managedObjectClassName$>Attributes <$managedObjectClassName$>Attributes = {<$foreach Attribute noninheritedAttributes do$>
+	.<$Attribute.name$> = @"<$Attribute.name$>",<$endforeach do$>
+};
+
+const struct <$managedObjectClassName$>Relationships <$managedObjectClassName$>Relationships = {<$foreach Relationship noninheritedRelationships do$>
+	.<$Relationship.name$> = @"<$Relationship.name$>",<$endforeach do$>
+};
+
+const struct <$managedObjectClassName$>FetchedProperties <$managedObjectClassName$>FetchedProperties = {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+	.<$FetchedProperty.name$> = @"<$FetchedProperty.name$>",<$endforeach do$>
+};
+
+@implementation <$managedObjectClassName$>ID
+@end
+
+@implementation _<$managedObjectClassName$>
+
++ (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_ {
+	NSParameterAssert(moc_);
+	return [NSEntityDescription insertNewObjectForEntityForName:@"<$name$>" inManagedObjectContext:moc_];
+}
+
++ (NSString*)entityName {
+	return @"<$name$>";
+}
+
++ (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_ {
+	NSParameterAssert(moc_);
+	return [NSEntityDescription entityForName:@"<$name$>" inManagedObjectContext:moc_];
+}
+
+- (<$managedObjectClassName$>ID*)objectID {
+	return (<$managedObjectClassName$>ID*)[super objectID];
+}
+
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
+	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
+	<$foreach Attribute noninheritedAttributes do$><$if Attribute.hasDefinedAttributeType$><$if Attribute.hasScalarAttributeType$>
+	if ([key isEqualToString:@"<$Attribute.name$>Value"]) {
+		NSSet *affectingKey = [NSSet setWithObject:@"<$Attribute.name$>"];
+		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+	}<$endif$><$endif$><$endforeach do$>
+
+	return keyPaths;
+}
+
+<$foreach Attribute noninheritedAttributes do$>
+<$if Attribute.hasDefinedAttributeType$>
+
+@dynamic <$Attribute.name$>;
+
+<$if Attribute.hasScalarAttributeType$>
+
+- (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value {
+	NSNumber *result = [self <$Attribute.name$>];
+	return [result <$Attribute.scalarAttributeType.camelCaseString$>Value];
+}
+
+- (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
+	[self set<$Attribute.name.initialCapitalString$>:[NSNumber numberWith<$Attribute.scalarAttributeType.camelCaseString.initialCapitalString$>:value_]];
+}
+
+- (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value {
+	NSNumber *result = [self primitive<$Attribute.name.initialCapitalString$>];
+	return [result <$Attribute.scalarAttributeType.camelCaseString$>Value];
+}
+
+- (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
+	[self setPrimitive<$Attribute.name.initialCapitalString$>:[NSNumber numberWith<$Attribute.scalarAttributeType.camelCaseString.initialCapitalString$>:value_]];
+}
+<$endif$>
+<$endif$>
+<$endforeach do$>
+
+<$foreach Relationship noninheritedRelationships do$>
+@dynamic <$Relationship.name$>;
+
+	<$if Relationship.isToMany$>
+- (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set {
+	[self willAccessValueForKey:@"<$Relationship.name$>"];
+  <$if Relationship.isOrdered$>
+	<$Relationship.mutableCollectionClassName$> *result = (<$Relationship.mutableCollectionClassName$>*)[self mutableOrderedSetValueForKey:@"<$Relationship.name$>"];
+  <$else$>
+	<$Relationship.mutableCollectionClassName$> *result = (<$Relationship.mutableCollectionClassName$>*)[self mutableSetValueForKey:@"<$Relationship.name$>"];
+  <$endif$>
+	[self didAccessValueForKey:@"<$Relationship.name$>"];
+	return result;
+}
+	<$endif$>
+<$endforeach do$>
+
+<$foreach FetchedProperty noninheritedFetchedProperties do$>
+@dynamic <$FetchedProperty.name$>;
+<$endforeach do$>
+
+<$foreach FetchRequest prettyFetchRequests do$>
+<$if FetchRequest.singleResult$>
++ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
+	NSError *error = nil;
+	id result = [self fetch<$FetchRequest.name.initialCapitalString$>:moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:<$Binding.name$>_ <$endforeach do2$>error:&error];
+	if (error) {
+#if TARGET_OS_IPHONE
+		NSLog(@"error: %@", error);
+#else
+		[NSApp presentError:error];
+#endif
+	}
+	return result;
+}
++ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
+	NSParameterAssert(moc_);
+	NSError *error = nil;
+	
+	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
+	<$if FetchRequest.hasBindings$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
+														<$foreach Binding FetchRequest.bindings do2$>
+														<$Binding.name$>_, @"<$Binding.name$>",
+														<$endforeach do2$>
+														nil];
+	<$else$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionary];
+	<$endif$>
+	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
+													 substitutionVariables:substitutionVariables];
+	NSAssert(fetchRequest, @"Can't find fetch request named \"<$FetchRequest.name$>\".");
+	
+	id result = nil;
+	NSArray *results = [moc_ executeFetchRequest:fetchRequest error:&error];
+	
+	if (!error) {
+		switch ([results count]) {
+			case 0:
+				//	Nothing found matching the fetch request. That's cool, though: we'll just return nil.
+				break;
+			case 1:
+				result = [results objectAtIndex:0];
+				break;
+			default:
+				NSLog(@"WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, %u found (substitutionVariables:%@, results:%@)",
+					[results count],
+					substitutionVariables,
+					results);
+		}
+	}
+	
+	if (error_) *error_ = error;
+	return result;
+}
+<$else$>
++ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
+	NSError *error = nil;
+	NSArray *result = [self fetch<$FetchRequest.name.initialCapitalString$>:moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:<$Binding.name$>_ <$endforeach do2$>error:&error];
+	if (error) {
+#if TARGET_OS_IPHONE
+		NSLog(@"error: %@", error);
+#else
+		[NSApp presentError:error];
+#endif
+	}
+	return result;
+}
++ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
+	NSParameterAssert(moc_);
+	NSError *error = nil;
+	
+	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
+	<$if FetchRequest.hasBindings$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
+														<$foreach Binding FetchRequest.bindings do2$>
+														<$Binding.name$>_, @"<$Binding.name$>",
+														<$endforeach do2$>
+														nil];
+	<$else$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionary];
+	<$endif$>									
+	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
+													 substitutionVariables:substitutionVariables];
+	NSAssert(fetchRequest, @"Can't find fetch request named \"<$FetchRequest.name$>\".");
+	
+	NSArray *result = [moc_ executeFetchRequest:fetchRequest error:&error];
+	if (error_) *error_ = error;
+	return result;
+}
+<$endif$>
+<$endforeach do$>
+@end

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -380,6 +380,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
     {@"template-group",		0,      DDGetoptRequiredArgument},
     {@"list-source-files",	0,      DDGetoptNoArgument},
     {@"orphaned",			0,      DDGetoptNoArgument},
+	{@"use-pbx-vars",		0,		DDGetoptNoArgument},
 
     {@"help",				'h',    DDGetoptNoArgument},
     {@"version",			0,      DDGetoptNoArgument},
@@ -406,6 +407,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
            "  -H, --human-dir DIR           Output directory for human files\n"
 		   "      --list-source-files		Only list model-related source files\n"
            "      --orphaned                Only list files whose entities no longer exist\n"
+		   "      --use-pbx-vars			Pass Xcode PBXCustomTemplateMacroDefinitions key-value pairs to the template file\n"
            "      --version                 Display version and exit\n"
            "  -h, --help                    Display this help and exit\n"
            "\n"
@@ -439,6 +441,25 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
 	}
 	
 	return result;
+}
+
+-(void)setUsePbxVars:(BOOL)val
+{
+	NSDictionary *pbxPrefs = (NSDictionary*)CFPreferencesCopyValue(CFSTR("PBXCustomTemplateMacroDefinitions"), 
+																   CFSTR("com.apple.Xcode"), 
+																   kCFPreferencesCurrentUser, 
+																   kCFPreferencesAnyHost);
+	[templateVar addEntriesFromDictionary:pbxPrefs];
+	time_t curTime = time(NULL);
+	struct tm *tm = localtime(&curTime);
+	[templateVar setObject:[NSString stringWithFormat:@"%ld", 1900 + tm->tm_year] forKey:@"YEAR"];
+	NSDateFormatter *df = [[[NSDateFormatter alloc] init] autorelease];
+	[df setDateStyle:NSDateFormatterShortStyle];
+	[df setTimeStyle:NSDateFormatterNoStyle];
+	[templateVar setObject:[df stringFromDate:[NSDate date]] forKey:@"DATE"];
+	[templateVar setObject:NSFullUserName() forKey:@"FULLUSERNAME"];
+	[pbxPrefs release];
+	NSLog(@"using pbx vars: %@", templateVar);
 }
 
 - (void)setModel:(NSString*)path;


### PR DESCRIPTION
Added a --use-pbx-vars option that adds to TemplateVar the standard and custom macros Xcode uses when generating files from templates.Also added contributed templates that include the Xcode-like comments at the top of the generated files.