### PR TITLE
Allow per-entity definition of custom base class

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -23,6 +23,7 @@
 @interface NSEntityDescription (customBaseClass)
 - (BOOL)hasCustomSuperentity;
 - (NSString*)customSuperentity;
+- (NSString*)forcedCustomBaseClass;
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_;
 - (NSArray*)prettyFetchRequests;
 @end

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -67,7 +67,8 @@ NSString	*gCustomBaseClassForced;
 	}
 }
 - (NSString*)customSuperentity {
-	if(!gCustomBaseClassForced) {
+	NSString *forcedBaseClass = [self forcedCustomBaseClass];
+	if(!forcedBaseClass) {
 		NSEntityDescription *superentity = [self superentity];
 		if (superentity) {
 			return [superentity managedObjectClassName];
@@ -75,8 +76,12 @@ NSString	*gCustomBaseClassForced;
 			return gCustomBaseClass ? gCustomBaseClass : @"NSManagedObject";
 		}
 	} else {
-		return gCustomBaseClassForced;
+		return forcedBaseClass;
 	}
+}
+- (NSString*)forcedCustomBaseClass {
+	NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:@"mogenerator.customBaseClass"];
+	return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
 }
 /** @TypeInfo NSAttributeDescription */
 - (NSArray*)noninheritedAttributes {


### PR DESCRIPTION
I often use a custom base class to supply general utility routines for my managed objects.

Occasionally those utility routines are specific to a certain subset of my Entities.

This pull request allows you to override the custom base class per-Entity by way of a key/value pair in the Entity userInfo (mogenerator.customBaseClass). 

It treats the userInfo-defined custom base class as a 'forced' custom base class for just that Entity, overriding any command line argument for --base-class-force.
