### PR TITLE
private interface declaration

### DIFF
--- a/templates/human.m.motemplate
+++ b/templates/human.m.motemplate
@@ -1,5 +1,13 @@
 #import "<$managedObjectClassName$>.h"
 
+
+@interface <$managedObjectClassName$> ()
+
+// Private interface goes here.
+
+@end
+
+
 @implementation <$managedObjectClassName$>
 
 // Custom logic goes here.


### PR DESCRIPTION
As in Xcode 4.3 the .m file template has now a private interface declaration.

Signed-off-by: Jonas Schnelli jonas.schnelli@include7.ch
