### PR TITLE
Fixed an issue with the default template for transformable attributes

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -32,9 +32,9 @@ extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach Fetch
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
 <$if TemplateVar.arc$>
-@property (nonatomic, strong) <$Attribute.objectAttributeType$><$Attribute.name$>;
+@property (nonatomic, strong) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
-@property (nonatomic, retain) <$Attribute.objectAttributeType$><$Attribute.name$>;
+@property (nonatomic, retain) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
 @property <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;


### PR DESCRIPTION
Transformable attributes have type id, so there needs to be a space after the type name in order to complie properly.
