### PR TITLE
Option to limit processing to a specified configuration

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -17,7 +17,7 @@
 #import "DDCommandLineInterface.h"
 
 @interface NSManagedObjectModel (entitiesWithACustomSubclassVerbose)
-- (NSArray*)entitiesWithACustomSubclassVerbose:(BOOL)verbose_;
+- (NSArray*)entitiesWithACustomSubclassInConfiguration:(NSString *)configuration_ verbose:(BOOL)verbose_;
 @end
 
 @interface NSEntityDescription (customBaseClass)
@@ -56,6 +56,7 @@
 	NSString				*origModelBasePath;
 	NSString				*tempMOMPath;
 	NSManagedObjectModel	*model;
+	NSString				*configuration;
 	NSString				*baseClass;
 	NSString				*baseClassForce;
 	NSString				*includem;


### PR DESCRIPTION
I'm running into a situation in a current project where I'm splitting up my model into configurations that will live in separate stores, and it would be useful to process each set of entities with different templates/options. This really just necessitated surfacing an additional option, and then passing it through to the method that gathers the set of entities for processing. (Or, at least, it _seemed_ so; hopefully, I haven't missed some subtleties.)

In the hopes that this might be useful to others, here are my changes.
