### PR TITLE
[FIX] Missing import with per entity custom base class

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -73,11 +73,16 @@ NSString	*gCustomBaseClassForced;
 
 @implementation NSEntityDescription (customBaseClass)
 - (BOOL)hasCustomSuperentity {
-	NSEntityDescription *superentity = [self superentity];
-	if (superentity) {
-		return YES;
+	NSString *forcedBaseClass = [self forcedCustomBaseClass];
+	if (!forcedBaseClass) {
+		NSEntityDescription *superentity = [self superentity];
+		if (superentity) {
+			return YES;
+		} else {
+			return gCustomBaseClass ? YES : NO;
+		}
 	} else {
-		return gCustomBaseClass ? YES : NO;
+		return YES;
 	}
 }
 - (NSString*)customSuperentity {


### PR DESCRIPTION
Wasn't importing any header when using `mogenerator.customBaseClass` entity userInfo key as `-[NSEntityDescription hasCustomSuperentity]` wasn't aware of the option.
