### PR TITLE
Allow an attribute property to be specified readonly

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -37,6 +37,7 @@
 - (NSString*)objectAttributeClassName;
 - (NSString*)objectAttributeType;
 - (BOOL)hasTransformableAttributeType;
+- (BOOL)isReadonly;
 @end
 
 @interface NSRelationshipDescription (collectionClassName)

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -356,6 +356,15 @@ NSString	*gCustomBaseClassForced;
 - (BOOL)hasTransformableAttributeType {
 	return ([self attributeType] == NSTransformableAttributeType);
 }
+
+- (BOOL)isReadonly {
+    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:@"mogenerator.readonly"];
+    if (readonlyUserinfoValue != nil) {
+        return YES;
+    }
+    return NO;
+}
+
 @end
 
 @implementation NSRelationshipDescription (collectionClassName)

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -32,9 +32,17 @@ extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach Fetch
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
 <$if TemplateVar.arc$>
+<$if Attribute.isReadonly$>
+@property (nonatomic, strong, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$else$>
 @property (nonatomic, strong) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$endif$>
+<$else$>
+<$if Attribute.isReadonly$>
+@property (nonatomic, retain, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
 @property (nonatomic, retain) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$endif$>
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
 @property <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;


### PR DESCRIPTION
I've had several cases where I don't properties to be changed after their initial values are set. It's handy to document (if not enforce) that via a readonly property.
