### PR TITLE
solving assertion failure when parsing fetch request

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -518,7 +518,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
 
 - (void) printUsage;
 {
-    ddprintf(@"%@: : ) Usage [OPTIONS] <argument> [...]\n", DDCliApp);
+    ddprintf(@"%@: Usage [OPTIONS] <argument> [...]\n", DDCliApp);
     printf("\n"
            "  -m, --model MODEL             Path to model\n"
            "  -C, --configuration CONFIG    Only consider entities included in the named configuration\n"


### PR DESCRIPTION
Hi rentzsch, im referencing:https://github.com/rentzsch/mogenerator/issues/81

 I ran into this problem with one of my fetch requests, and I propose the fix above. What was happening is that the _resolveKeyPathType: fails when the key path contains an attribute. I hope this is helpful. Let me know if I can clarify anything.
