### PR TITLE
Correct generation of fetch requests with repeated variables

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -179,7 +179,6 @@ NSString	*gCustomBaseClassForced;
 	return [entity managedObjectClassName];
 }
 
-// changes by Sergei Winitzki
 // auxiliary function
 - (BOOL) bindingsArray:(NSArray *)bindings containsVariableNamed:(NSString *)name {
 	for (NSDictionary *dict in bindings) {
@@ -189,7 +188,6 @@ NSString	*gCustomBaseClassForced;
 	}
 	return NO;
 }
-// end of changes by Sergei Winitzki
 
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_ {
     if (!predicate_) return;
@@ -221,13 +219,13 @@ NSString	*gCustomBaseClassForced;
                     type = [self _resolveKeyPathType:[lhs keyPath]];
                 }
                 type = [type stringByAppendingString:@"*"];
-                // changes by Sergei Winitzki: make sure that no repeated variables are entered here.
+                // make sure that no repeated variables are entered here.
 				if (![self bindingsArray:bindings_ containsVariableNamed:[rhs variable]]) {
 					[bindings_ addObject:[NSDictionary dictionaryWithObjectsAndKeys:
                                       [rhs variable], @"name",
                                       type, @"type",
                                       nil]];
-				} // end of changes by Sergei Winitzki
+				}
 			} break;
 			default:
 				assert(0 && "unknown NSExpression type");


### PR DESCRIPTION
If a CoreData model has a fetch request with a predicate where some variables are repeated, mogenerator will now generate correct Objective-C code.

Example: Suppose a CoreData model has a fetch request with predicate (name==$NAME AND id==$ID ) OR ( surname==$NAME AND id="special"). In this predicate, the variable $NAME is mentioned twice. The current version of mogenerator exports such a fetch request as a function with declaration of this form,
- (NSArray_)fetchGetWhatever:(NSManagedObjectContext_)moc_ NAME:(NSString*)NAME_ ID:(NSString *)ID_ NAME:(NSString *)NAME_;

This does not compile since the parameter "NAME_" is used twice.

My patch corrects this problem and makes sure that variables are used only once.
