### PR TITLE
Fix generated transformed property statements

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -359,7 +359,7 @@ NSString	*gCustomBaseClassForced;
 	} else if ([result rangeOfString:@"<"].location != NSNotFound) {
 		// `id<Protocol1,Protocol2>` (don't append asterisk).
 	} else if ([result isEqualToString:@"NSObject"]) {
-		result = @"id";
+		result = @"id ";
 	} else {
 		result = [result stringByAppendingString:@"*"]; // Make it a pointer.
 	}


### PR DESCRIPTION
Inserting space after type "id" so that the @property statements generated for transformed properties are correct.
