### PR TITLE
Added the empty string as classname for entities that should be skipped

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -55,7 +55,7 @@ NSString	*gCustomBaseClassForced;
 	nsenumerate (allEntities, NSEntityDescription, entity) {
 		NSString *entityClassName = [entity managedObjectClassName];
 		
-		if ([entityClassName isEqualToString:@"NSManagedObject"] || [entityClassName isEqualToString:gCustomBaseClass]){
+		if ([entityClassName isEqualToString:@"NSManagedObject"] || [entityClassName isEqualToString:@""] || [entityClassName isEqualToString:gCustomBaseClass]){
 			if (verbose_) {
 				ddprintf(@"skipping entity %@ (%@) because it doesn't use a custom subclass.\n", 
 						 entity.name, entityClassName);


### PR DESCRIPTION
This fixes issue #105.
Recent versions of Xcode use the empty string as default when an entity doesn't have a custom subclass. 
