### PR TITLE
Support newly-created models when --model=*.xcdatamodeld

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -610,6 +610,16 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
                 momOrXCDataModelFilePath = [momOrXCDataModelFilePath stringByAppendingPathComponent:currentModelName];
             }
         }
+        else {
+            // Freshly created models with only one version do NOT have a .xccurrentversion file, but only have one model
+            // in them.  Use that model.
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self endswith %@", @".xcdatamodel"];
+            NSArray *contents = [[fm contentsOfDirectoryAtPath:momOrXCDataModelFilePath error:nil]
+                                   filteredArrayUsingPredicate:predicate];
+            if (contents.count == 1) {
+                momOrXCDataModelFilePath = [momOrXCDataModelFilePath stringByAppendingPathComponent:[contents lastObject]];
+            }
+        }
     }
     
     NSString *momFilePath = nil;


### PR DESCRIPTION
When models are freshly created, they only have one version and no 
.xccurrentversion file.  In this case, and only in this case, assume the 
only present model is the desired model.

Fixes #137
