### PR TITLE
Implement ordered set accessors

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -92,14 +92,14 @@ extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach Fetch
 <$endif$>
 @end
 
-@interface _<$managedObjectClassName$> (CoreDataGeneratedAccessors)
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
+@interface _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
 - (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
 - (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
-<$endif$><$endforeach do$>
 @end
+<$endif$><$endforeach do$>
 
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
 <$foreach Attribute noninheritedAttributes do$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -214,3 +214,22 @@ const struct <$managedObjectClassName$>FetchedProperties <$managedObjectClassNam
 #endif
 <$endif$>
 @end
+
+<$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$><$if Relationship.jr_isOrdered$>
+@implementation _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
+- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
+	[self.<$Relationship.name$>Set unionOrderedSet:value_];
+}
+- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
+	[self.<$Relationship.name$>Set minusOrderedSet:value_];
+}
+- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
+	[self.<$Relationship.name$>Set addObject:value_];
+}
+- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
+	[self.<$Relationship.name$>Set removeObject:value_];
+}
+@end
+<$endif$><$endif$><$endforeach do$>
+
+


### PR DESCRIPTION
The Apple generated accessors for ordered sets crash, this is described further in the radar bugs listed below.

I've added implementations for ordered to-many relationships, but because of Xcode will warn you about not implementing all the methods in a category, I've separated each relationship's accessor method declarations.

After two iterations of OS I would have thought they would have fixed this bug. :-/

Those radars:
http://openradar.appspot.com/10946479
http://openradar.appspot.com/12085926
http://openradar.appspot.com/11119497
http://openradar.appspot.com/12418689
