### PR TITLE
Do not generate scalar setter for readonly properties

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -46,9 +46,14 @@ extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach Fetch
 <$endif$>
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
+<$if Attribute.isReadonly$>
+@property (readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
+- (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
+<$else$>
 @property <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 //- (BOOL)validate<$Attribute.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
 <$endif$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -62,9 +62,11 @@ const struct <$managedObjectClassName$>FetchedProperties <$managedObjectClassNam
 	return [result <$Attribute.scalarAccessorMethodName$>];
 }
 
+<$if ! Attribute.isReadonly$>
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
 	[self set<$Attribute.name.initialCapitalString$>:[NSNumber <$Attribute.scalarFactoryMethodName$>value_]];
 }
+<$endif$>
 
 - (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value {
 	NSNumber *result = [self primitive<$Attribute.name.initialCapitalString$>];


### PR DESCRIPTION
Modified machine templates so as not to generate scalar setters for readonly properties
