### PR TITLE
Don't touch aggregate include file if the content doesn't change.

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -956,13 +956,13 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         [fm removeItemAtPath:tempGeneratedMomFilePath error:nil];
     }
     bool mfileGenerated = NO;
-    if (mfilePath && ![mfileContent isEqualToString:@""]) {
+    if (mfilePath && ![mfileContent isEqualToString:@""] && (![fm regularFileExistsAtPath:mfilePath] || ![[NSString stringWithContentsOfFile:mfilePath encoding:NSUTF8StringEncoding error:nil] isEqualToString:mfileContent])) {
         [mfileContent writeToFile:mfilePath atomically:NO encoding:NSUTF8StringEncoding error:nil];
         mfileGenerated = YES;
     }
 
     bool hfileGenerated = NO;
-    if (hfilePath && ![hfileContent isEqualToString:@""]) {
+    if (hfilePath && ![hfileContent isEqualToString:@""] && (![fm regularFileExistsAtPath:hfilePath] || ![[NSString stringWithContentsOfFile:hfilePath encoding:NSUTF8StringEncoding error:nil] isEqualToString:hfileContent])) {
         [hfileContent writeToFile:hfilePath atomically:NO encoding:NSUTF8StringEncoding error:nil];
         hfileGenerated = YES;
     }


### PR DESCRIPTION
mogenerator re-creates the aggregate include file every time. In my case I added mogenerator as build phase and the touched include file force the compiler to re-compile all depending files. If I include it into the pre-compiled header this makes it even worse.

In my commit I compare the content to see if the file changed.
