### PR TITLE
Escape spaces in the build mogen path, fixes #151

### DIFF
--- a/test/Rakefile
+++ b/test/Rakefile
@@ -15,7 +15,7 @@ mogenPath = "#{built_products_dir}/mogenerator"
 def gen_and_compile(desc, mogenPath, extra_mogen_args, extra_gcc_args)
   puts "*** Testing #{desc}"
   ENV['MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS'] = '1'
-  run_or_die "#{mogenPath} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
+  run_or_die "#{mogenPath.gsub(/ /, '\\ ')} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
   run_or_die 'cp HumanMO.h HumanMO.m MyProtocol.h TestProtocol.m MOs'
   run_or_die "clang -o testbin test.m MyBaseClass.m MOs/*.m -I#{Dir.pwd} -framework Foundation -framework Cocoa -framework CoreData #{extra_gcc_args}"
   run_or_die "xcrun momc -MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS test.xcdatamodel #{Dir.pwd}/test.mom"


### PR DESCRIPTION
I'm not sure if this is the best way to do it, but this escapes the spaces in the built mogenerator path.
