### PR TITLE
Explicitly declare property atomic to resolve Xcode warning

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -52,10 +52,10 @@ extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach Fetch
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
-@property (readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
+@property (atomic, readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 <$else$>
-@property <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
+@property (atomic) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
 <$endif$>


### PR DESCRIPTION
Without explicitly declaring the property to be atomic, Xcode raises the following warning when the -Weverything compiler flag is used.

> Atomic by default property 'statusCodeValue' has a user defined getter (property should be marked 'atomic' if this is intended)
