### PR TITLE
Add custom attribute setter semantics.

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -39,6 +39,8 @@
 - (NSString*)objectAttributeClassName;
 - (NSString*)objectAttributeType;
 - (BOOL)hasTransformableAttributeType;
+- (NSString*)objectAttributeSetterSemantics;
+- (BOOL)hasAttributeSetterSemantics;
 - (BOOL)isReadonly;
 @end
 

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -454,6 +454,16 @@ NSString  *gCustomBaseClassForced;
 - (BOOL)hasTransformableAttributeType {
     return ([self attributeType] == NSTransformableAttributeType);
 }
+- (NSString*)objectAttributeSetterSemantics
+{
+    NSString *result = nil;
+    result = [[self userInfo] objectForKey:@"attributeSetterSemantics"];
+    return result;
+}
+- (BOOL)hasAttributeSetterSemantics
+{
+    return [[self userInfo] objectForKey:@"attributeSetterSemantics"];
+}
 
 - (BOOL)isReadonly {
     NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:@"mogenerator.readonly"];

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -51,15 +51,31 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$if Attribute.hasDefinedAttributeType$>
 <$if TemplateVar.arc$>
 <$if Attribute.isReadonly$>
+<$if Attribute.hasAttributeSetterSemantics$>
+@property (nonatomic, <$Attribute.objectAttributeSetterSemantics$>, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$else$>
 @property (nonatomic, strong, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$endif$>
+<$else$>
+<$if Attribute.hasAttributeSetterSemantics$>
+@property (nonatomic, <$Attribute.objectAttributeSetterSemantics$>) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
 @property (nonatomic, strong) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$endif$>
+<$endif$>
 <$else$>
 <$if Attribute.isReadonly$>
+<$if Attribute.hasAttributeSetterSemantics$>
+@property (nonatomic, <$Attribute.objectAttributeSetterSemantics$>, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$else$>
 @property (nonatomic, retain, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$endif$>
+<$else$>
+<$if Attribute.hasAttributeSetterSemantics$>
+@property (nonatomic, <$Attribute.objectAttributeSetterSemantics$>) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
 @property (nonatomic, retain) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+<$endif$>
 <$endif$>
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>


### PR DESCRIPTION
The memory management attribute of a property can now be set by using
the key "attributeSetterSemantics". If it is not set, it defaults to
strong/retain. This does not work for relationships!

References #41, #84