### PR TITLE
Add a warning when skipping an attribute named 'type'

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -164,7 +164,10 @@ NSString  *gCustomBaseClassForced;
     NSMutableArray *filteredAttributeDescriptions = [NSMutableArray arrayWithCapacity:[attributeDescriptions count]];
     
     nsenumerate(attributeDescriptions, NSAttributeDescription, attributeDescription) {
-        if (![[attributeDescription name] isEqualToString:@"type"]) {
+        if ([[attributeDescription name] isEqualToString:@"type"]) {
+            ddprintf(@"WARNING skipping 'type' attribute on %@ (%@) - see https://github.com/rentzsch/mogenerator/issues/74\n",
+                     self.name, self.managedObjectClassName);
+        } else {
             [filteredAttributeDescriptions addObject:attributeDescription];
         }
     }


### PR DESCRIPTION
Just spent a fun ten minutes with `git bisect` figuring out why `mogenerator` was chomping my `setPrimitiveType:` method. This pull request is for the benefit of our children and our children's children. :)
