### PR TITLE
Insert a #warning if generating a setPrimitiveType: accessor

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -159,21 +159,6 @@ NSString  *gCustomBaseClassForced;
     }
 }
 /** @TypeInfo NSAttributeDescription */
-- (NSArray*)noninheritedAttributesSansType {
-    NSArray *attributeDescriptions = [self noninheritedAttributes];
-    NSMutableArray *filteredAttributeDescriptions = [NSMutableArray arrayWithCapacity:[attributeDescriptions count]];
-    
-    nsenumerate(attributeDescriptions, NSAttributeDescription, attributeDescription) {
-        if ([[attributeDescription name] isEqualToString:@"type"]) {
-            ddprintf(@"WARNING skipping 'type' attribute on %@ (%@) - see https://github.com/rentzsch/mogenerator/issues/74\n",
-                     self.name, self.managedObjectClassName);
-        } else {
-            [filteredAttributeDescriptions addObject:attributeDescription];
-        }
-    }
-    return filteredAttributeDescriptions;
-}
-/** @TypeInfo NSAttributeDescription */
 - (NSArray*)noninheritedRelationships {
     NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
     NSEntityDescription *superentity = [self superentity];

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -125,8 +125,11 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$endif$><$endforeach do$>
 
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
-<$foreach Attribute noninheritedAttributesSansType do$>
+<$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
+<$if Attribute.name=="type"$>
+#warning A setPrimitiveType: accessor is known to potentially cause App Store rejection. See https://github.com/rentzsch/mogenerator/issues/74. If this app is intended for App Store distribution you should rename the 'type' attribute in your model (e.g. to '<$name.lowercaseString$>Type') and re-run mogenerator.
+<$endif$>
 - (<$Attribute.objectAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>)value;
 <$if Attribute.hasScalarAttributeType$>


### PR DESCRIPTION
This is a suggested alternative to the fix in commit cd9809d. That fix results in the `primitiveType` and `setPrimitiveType:` accessors being silently suppressed. This fix still generates them (and hence doesn't break a build), but adds a #warning line (which Xcode will flag up) indicating that there's a problem if the app is intended for App Store submission.