### PR TITLE
Declare an array proxy property for ordered relationships

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -117,7 +117,12 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
 @interface _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
-- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+<$if Relationship.jr_isOrdered$>- (NSArray*)<$Relationship.name$>Array;
+- (void)insert<$Relationship.name.initialCapitalString$>Array:(NSArray*)value_ atIndexes:(NSIndexSet*)indexes_;
+- (void)remove<$Relationship.name.initialCapitalString$>ArrayAtIndexes:(NSIndexSet*)indexes_;
+- (void)insertObject:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ in<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_;
+- (void)removeObjectFrom<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_;
+<$endif$>- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
 - (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -117,16 +117,20 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
 @interface _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
-<$if Relationship.jr_isOrdered$>- (NSArray*)<$Relationship.name$>Array;
+- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
+- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
+@end<$if Relationship.jr_isOrdered$>
+
+@interface _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>ArrayAccessors)
+@property (readonly) NSArray * <$Relationship.name$>Array;
 - (void)insert<$Relationship.name.initialCapitalString$>Array:(NSArray*)value_ atIndexes:(NSIndexSet*)indexes_;
 - (void)remove<$Relationship.name.initialCapitalString$>ArrayAtIndexes:(NSIndexSet*)indexes_;
 - (void)insertObject:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ in<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_;
 - (void)removeObjectFrom<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_;
-<$endif$>- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
-- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
-- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
-- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
 @end
+<$endif$>
 <$endif$><$endforeach do$>
 
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -231,6 +231,27 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$><$if Relationship.jr_isOrdered$>
 @implementation _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
+
+- (NSArray*)<$Relationship.name$>Array {
+    return [self.<$Relationship.name$>Set array];
+}
+
+- (void)insert<$Relationship.name.initialCapitalString$>Array:(NSArray*)value_ atIndexes:(NSIndexSet*)indexes_ {
+    [self.<$Relationship.name$>Set insertObjects:value_ atIndexes:indexes_];
+}
+
+- (void)remove<$Relationship.name.initialCapitalString$>ArrayAtIndexes:(NSIndexSet*)indexes_ {
+    [self.<$Relationship.name$>Set removeObjectsAtIndexes:indexes_];
+}
+
+- (void)insertObject:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ in<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_ {
+    [self.<$Relationship.name$>Set insertObject:value_ atIndex:index_];
+}
+
+- (void)removeObjectFrom<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_ {
+    [self.<$Relationship.name$>Set removeObjectAtIndex:index_];
+}
+
 - (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
 	[self.<$Relationship.name$>Set unionOrderedSet:value_];
 }
@@ -243,6 +264,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 - (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
 	[self.<$Relationship.name$>Set removeObject:value_];
 }
+
 @end
 <$endif$><$endif$><$endforeach do$>
 

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -232,6 +232,23 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$><$if Relationship.jr_isOrdered$>
 @implementation _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
 
+- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
+	[self.<$Relationship.name$>Set unionOrderedSet:value_];
+}
+- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
+	[self.<$Relationship.name$>Set minusOrderedSet:value_];
+}
+- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
+	[self.<$Relationship.name$>Set addObject:value_];
+}
+- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
+	[self.<$Relationship.name$>Set removeObject:value_];
+}
+
+@end
+
+@implementation _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>ArrayAccessors)
+
 - (NSArray*)<$Relationship.name$>Array {
     return [self.<$Relationship.name$>Set array];
 }
@@ -250,19 +267,6 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 - (void)removeObjectFrom<$Relationship.name.initialCapitalString$>ArrayAtIndex:(NSUInteger)index_ {
     [self.<$Relationship.name$>Set removeObjectAtIndex:index_];
-}
-
-- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
-	[self.<$Relationship.name$>Set unionOrderedSet:value_];
-}
-- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_ {
-	[self.<$Relationship.name$>Set minusOrderedSet:value_];
-}
-- (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
-	[self.<$Relationship.name$>Set addObject:value_];
-}
-- (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_ {
-	[self.<$Relationship.name$>Set removeObject:value_];
 }
 
 @end


### PR DESCRIPTION
This change defines a new `readonly` property of the form `(name)Array` for each ordered to-many relationship which returns the ordered set's `-array` proxy. It also defines ordered insertion and removal methods for `(name)Array` sufficient to make `-mutableArrayValueForKey:` work. This combination seems to allow you to bind an ordered relationship to an `NSArrayController` (though I wouldn't recommend mutating the relationship through one of the other accessors).