### PR TITLE
Allow a relationship property to be qualified as readonly via userinfo

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -46,6 +46,7 @@
 - (NSString*)mutableCollectionClassName;
 - (NSString*)immutableCollectionClassName;
 - (BOOL)jr_isOrdered;
+- (BOOL)isReadonly;
 @end
 @interface NSObject (JustHereToSuppressIsOrderedNotImplementedCompilerWarning)
 - (BOOL)isOrdered;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -486,6 +486,14 @@ NSString  *gCustomBaseClassForced;
     }
 }
 
+- (BOOL)isReadonly {
+    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:@"mogenerator.readonly"];
+    if (readonlyUserinfoValue != nil) {
+        return YES;
+    }
+    return NO;
+}
+
 @end
 
 @implementation NSString (camelCaseString)

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -78,16 +78,16 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
 <$if TemplateVar.arc$>
-@property (nonatomic, strong) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
+@property (<$if Relationship.isReadonly$>readonly, <$endif$>nonatomic, strong) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
 <$else$>
-@property (nonatomic, retain) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
+@property (<$if Relationship.isReadonly$>readonly, <$endif$>nonatomic, retain) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
 <$endif$>
 - (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
 <$else$>
 <$if TemplateVar.arc$>
-@property (nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
+@property (<$if Relationship.isReadonly$>readonly, <$endif$>nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
 <$else$>
-@property (nonatomic, retain) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
+@property (<$if Relationship.isReadonly$>readonly, <$endif$>nonatomic, retain) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
 <$endif$>
 //- (BOOL)validate<$Relationship.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
 <$endif$>


### PR DESCRIPTION
Much like #111, it is useful to specify relationships as readonly properties. This is done via `mogenerator.readonly` userInfo key for specified relationship.