### PR TITLE
Add support for custom scalar attribute types…

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -342,6 +342,8 @@ NSString  *gCustomBaseClassForced;
     }
 }
 - (NSString*)scalarAttributeType {
+    NSString *customAttributeType = [[self userInfo] objectForKey: @"scalarAttributeType"];
+    if (customAttributeType != nil) return customAttributeType;
     switch ([self attributeType]) {
         case NSInteger16AttributeType:
             return @"int16_t";


### PR DESCRIPTION
…using the `scalarAttributeType` user info key.

Partially resolves #162.

Possible issues:
- Namespace? For now, there's no `mogenerator.` prefix because I just named the info dictionary key after the method that uses it.
- Still no easy way of using custom `#import`s for user-defined types. I solved this problem by importing the appropriate headers in the 'human' header of my base class (since I was only using custom scalar types in sub-entities anyway) but that's not a solution for everyone. Regardless, it's useful for Foundation types like `NSTimeInterval` and friends.

Although the generated scalar accessors will utilize the given type to box/unbox and cast without issues, Core Data (obviously) still constrains values to the "real" storage type of the attribute set in the data model.
Therefore, it's the developer's responsibility to make sure to only use values both types — i.e. the "real" attribute type set in the model and the custom one used in the generated classes — support, to mitigate casting/overflow/underflow issues.
