### PR TITLE
Add method that counts matching objects in fetch request

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -100,6 +100,8 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 + (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
 + (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
 <$endif$>
++ (NSUInteger)count<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
++ (NSUInteger)count<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
 <$endforeach do$>
 <$foreach FetchedProperty noninheritedFetchedProperties do$>
 @property (nonatomic, readonly) NSArray *<$FetchedProperty.name$>;

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -93,6 +93,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$endif$>
 <$endforeach do$>
 <$foreach FetchRequest prettyFetchRequests do$>
++ (NSFetchRequest *)fetchRequestFor<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
 <$if FetchRequest.singleResult$>
 + (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
 + (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -114,6 +114,26 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 <$endforeach do$>
 
 <$foreach FetchRequest prettyFetchRequests do$>
+#pragma mark - Fetch Request <$FetchRequest.name$>
+
++ (NSFetchRequest *)fetchRequestFor<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$> {
+	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
+	<$if FetchRequest.hasBindings$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
+														<$foreach Binding FetchRequest.bindings do2$>
+														<$Binding.name$>_, @"<$Binding.name$>",
+														<$endforeach do2$>
+														nil];
+	<$else$>
+	NSDictionary *substitutionVariables = [NSDictionary dictionary];
+	<$endif$>
+	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
+													 substitutionVariables:substitutionVariables];
+	NSAssert(fetchRequest, @"Can't find fetch request named \"<$FetchRequest.name$>\".");
+
+	return fetchRequest;
+}
+
 <$if FetchRequest.singleResult$>
 + (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
 	NSError *error = nil;
@@ -131,20 +151,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	NSParameterAssert(moc_);
 	NSError *error = nil;
 
-	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
-	<$if FetchRequest.hasBindings$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
-														<$foreach Binding FetchRequest.bindings do2$>
-														<$Binding.name$>_, @"<$Binding.name$>",
-														<$endforeach do2$>
-														nil];
-	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionary];
-	<$endif$>
-	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
-													 substitutionVariables:substitutionVariables];
-	NSAssert(fetchRequest, @"Can't find fetch request named \"<$FetchRequest.name$>\".");
-
+	NSFetchRequest *fetchRequest = [self fetchRequestFor<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>];
 	id result = nil;
 	NSArray *results = [moc_ executeFetchRequest:fetchRequest error:&error];
 
@@ -157,9 +164,9 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 				result = [results objectAtIndex:0];
 				break;
 			default:
-				NSLog(@"WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, %lu found (substitutionVariables:%@, results:%@)",
+				NSLog(@"WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, %lu found (predicate:%@, results:%@)",
 					(unsigned long)[results count],
-					substitutionVariables,
+					fetchRequest.predicate,
 					results);
 		}
 	}
@@ -184,25 +191,33 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	NSParameterAssert(moc_);
 	NSError *error = nil;
 
-	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
-	<$if FetchRequest.hasBindings$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
-														<$foreach Binding FetchRequest.bindings do2$>
-														<$Binding.name$>_, @"<$Binding.name$>",
-														<$endforeach do2$>
-														nil];
-	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionary];
-	<$endif$>
-	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
-													 substitutionVariables:substitutionVariables];
-	NSAssert(fetchRequest, @"Can't find fetch request named \"<$FetchRequest.name$>\".");
-
+	NSFetchRequest *fetchRequest = [self fetchRequestFor<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>];
 	NSArray *result = [moc_ executeFetchRequest:fetchRequest error:&error];
 	if (error_) *error_ = error;
 	return result;
 }
 <$endif$>
++ (NSUInteger)count<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
+	NSError *error = nil;
+	NSUInteger result = [self count<$FetchRequest.name.initialCapitalString$>:moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:<$Binding.name$>_ <$endforeach do2$>error:&error];
+	if (error) {
+#ifdef NSAppKitVersionNumber10_0
+		[NSApp presentError:error];
+#else
+		NSLog(@"error: %@", error);
+#endif
+	}
+	return result;
+}
++ (NSUInteger)count<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
+	NSParameterAssert(moc_);
+	NSError *error = nil;
+
+	NSFetchRequest *fetchRequest = [self fetchRequestFor<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>];
+    NSUInteger result = [moc_ countForFetchRequest:fetchRequest error:&error];
+	if (error_) *error_ = error;
+	return result;
+}
 <$endforeach do$>
 <$if TemplateVar.frc$>
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
It's probably a good idea to have a method that counts the matching objects of a fetchRequest. 
In theory you could use the fetch method that returns a NSArray and count yourself, but `countForFetchRequest:error:` will be much faster. 

Access to the substituted fetchRequest would be beneficial as well, especially if you create a NSFetchedResultsController or if you want to access the predicates defined in the model editor. 