### PR TITLE
Make scalar types in the machine-generated header optional, and disabled by default

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -62,7 +62,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 @property (nonatomic, retain) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$endif$>
 <$endif$>
-<$if Attribute.hasScalarAttributeType$>
+<$if TemplateVar.scalarTypes$><$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
 @property (atomic, readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
@@ -70,6 +70,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 @property (atomic) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 <$endif$>
 //- (BOOL)validate<$Attribute.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
@@ -129,9 +130,10 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$if Attribute.hasDefinedAttributeType$>
 - (<$Attribute.objectAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>)value;
-<$if Attribute.hasScalarAttributeType$>
+<$if TemplateVar.scalarTypes$><$if Attribute.hasScalarAttributeType$>
 - (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 <$endif$>
 <$endforeach do$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -50,6 +50,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	return (<$managedObjectClassName$>ID*)[super objectID];
 }
 
+<$if TemplateVar.scalarTypes$>
 + (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
 	<$foreach Attribute noninheritedAttributes do$><$if Attribute.hasDefinedAttributeType$><$if Attribute.hasScalarAttributeType$>
@@ -61,13 +62,13 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 	return keyPaths;
 }
-
+<$endif$>
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
 
 @dynamic <$Attribute.name$>;
 
-<$if Attribute.hasScalarAttributeType$>
+<$if TemplateVar.scalarTypes$><$if Attribute.hasScalarAttributeType$>
 
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value {
 	NSNumber *result = [self <$Attribute.name$>];
@@ -88,6 +89,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
 	[self setPrimitive<$Attribute.name.initialCapitalString$>:<$if TemplateVar.noliterals$>[NSNumber <$Attribute.scalarFactoryMethodName$>value_]<$else$>@(value_)<$endif$>];
 }
+<$endif$>
 <$endif$>
 <$endif$>
 <$endforeach do$>


### PR DESCRIPTION
Pass `--template-var scalarTypes=1` to the command-line utility to re-enable scalar types if you use/need them.