### PR TITLE
Use a template variable to support module @import syntax

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -1,7 +1,7 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to <$managedObjectClassName$>.h instead.
 
-#import <CoreData/CoreData.h>
+<$if TemplateVar.modules$>@import CoreData;<$else$>#import <CoreData/CoreData.h><$endif$>
 <$if hasCustomSuperentity$><$if hasSuperentity$>#import "<$customSuperentity$>.h"
 <$else$><$if hasCustomBaseCaseImport$>#import <$baseClassImport$><$else$>#import "<$customSuperentity$>.h"<$endif$><$endif$><$endif$>
 


### PR DESCRIPTION
Without this fix, I get a warning of "treating #import as an import of module 'CoreData' [-Wauto-import]". This change allows you to include the template variable as such: "--template-var modules=true" when running mogenerator to output the imports of CoreData in the new module syntax: @import CoreData;
