### PR TITLE
Rename `+entityName`

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -43,7 +43,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 
 @interface _<$managedObjectClassName$> : <$customSuperentity$> {}
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
-+ (NSString*)entityName;
++ (NSString*)nameOfEntity;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
 - (<$managedObjectClassName$>ID*)objectID;
 

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -37,7 +37,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	return [NSEntityDescription insertNewObjectForEntityForName:@"<$name$>" inManagedObjectContext:moc_];
 }
 
-+ (NSString*)entityName {
++ (NSString*)nameOfEntity {
 	return @"<$name$>";
 }
 


### PR DESCRIPTION
Rename `+entityName` to `+nameOfEntity` to avoid a conflict with the `NSObject` private method of the same name. 

Refer to #196 for more details.
