### PR TITLE
Use customSuperentity for the objectID superclass

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -38,7 +38,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$endforeach do$>
 <$else$>@class <$Attribute.objectAttributeClassName$>;<$endif$><$endif$>
 <$endforeach do$>
-@interface <$managedObjectClassName$>ID : <$if hasSuperentity$><$customSuperentity$>ID<$else$>NSManagedObjectID<$endif$> {}
+@interface <$managedObjectClassName$>ID : <$customSuperentity$>ID {}
 @end
 
 @interface _<$managedObjectClassName$> : <$customSuperentity$> {}


### PR DESCRIPTION
Before this commit, with a subentity, I was getting an -Woverriding-method-mismatch warning.

This change mirrors the managed object superclass, but there was some logic that may have been needed for a reason, I'm unsure of.
