### PR TITLE
Fix for warnings in iOS 8

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -45,7 +45,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (<$managedObjectClassName$>ID*)objectID;
+@property (nonatomic, readonly, strong) <$managedObjectClassName$>ID* objectID;
 
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>


### PR DESCRIPTION
iOS 8 changes objectID from a getter to a @property.

This causes the following warnings with the old template:

"Type of property 'objectID' does not match type of accessor 'objectID'"
