### PR TITLE
Fix warnings with -Wexplicit-ownership-type on fetched properties

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -127,7 +127,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	}
 	return result;
 }
-+ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
++ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError* __autoreleasing *)error_ {
 	NSParameterAssert(moc_);
 	NSError *error = nil;
 
@@ -180,7 +180,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	}
 	return result;
 }
-+ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
++ (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError* __autoreleasing *)error_ {
 	NSParameterAssert(moc_);
 	NSError *error = nil;
 


### PR DESCRIPTION
When compiling with -Weverything (more specifically, -Wexplicit-ownership-type), clang produces the warning “method parameter of type 'NSError *__autoreleasing *' with no explicit ownership”.

__autoreleasing is the default for NSError**-like params, so this doesn’t change any behaviour, it just makes it explicit.

WDYT?