### PR TITLE
Fix swift template objc interoperability

### DIFF
--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,4 +1,4 @@
-@objc
+@objc(<$managedObjectClassName$>)
 class <$managedObjectClassName$>: _<$managedObjectClassName$> {
 
 	// Custom logic goes here.


### PR DESCRIPTION
As described in http://stackoverflow.com/a/24074692/518801 a NSFetchRequest returns NSManagedObjects instead of custom subclasses. This is fixed when `@objc(Subclass)` instead of just `@objc` is set.
