### PR TITLE
Fix swift entity names

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -24,6 +24,7 @@
 - (BOOL)hasCustomSuperentity;
 - (NSString*)customSuperentity;
 - (NSString*)forcedCustomBaseClass;
+- (NSString*)swiftEntityClassNameWithoutModule;
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_;
 - (NSArray*)prettyFetchRequests;
 @end

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -74,8 +74,8 @@ BOOL       gSwift;
     }
     
     nsenumerate (allEntities, NSEntityDescription, entity) {
-        NSString *entityClassName = [entity managedObjectClassName];
-        
+        NSString *entityClassName = [entity swiftEntityClassNameWithoutModule];
+
         if ([entity hasCustomClass]){
             [result addObject:entity];
         } else {
@@ -146,6 +146,16 @@ BOOL       gSwift;
 - (NSString*)forcedCustomBaseClass {
     NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:@"mogenerator.customBaseClass"];
     return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
+}
+
+- (NSString*)swiftEntityClassNameWithoutModule {
+    NSString *entityClassName = [self managedObjectClassName];
+
+    if (gSwift) {
+        entityClassName = [entityClassName pathExtension];
+    }
+
+    return entityClassName;
 }
 /** @TypeInfo NSAttributeDescription */
 - (NSArray*)noninheritedAttributes {
@@ -957,7 +967,8 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
             generatedHumanH = [generatedHumanH stringByReplacingOccurrencesOfRegex:@"([ \t]*(\n|\r|\r\n)){2,}" withString:@"\n\n"];
             generatedHumanM = [generatedHumanM stringByReplacingOccurrencesOfRegex:@"([ \t]*(\n|\r|\r\n)){2,}" withString:@"\n\n"];
             
-            NSString *entityClassName = [entity managedObjectClassName];
+            NSString *entityClassName = [entity swiftEntityClassNameWithoutModule];
+
             BOOL machineDirtied = NO;
             
             // Machine header files.

--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,5 +1,5 @@
-@objc(<$managedObjectClassName$>)
-class <$managedObjectClassName$>: _<$managedObjectClassName$> {
+@objc(<$swiftEntityClassNameWithoutModule$>)
+class <$swiftEntityClassNameWithoutModule$>: _<$swiftEntityClassNameWithoutModule$> {
 
 	// Custom logic goes here.
 

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -1,10 +1,10 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
-// Make changes to <$managedObjectClassName$>.swift instead.
+// Make changes to <$swiftEntityClassNameWithoutModule$>.swift instead.
 
 import CoreData
 
 @objc
-class _<$managedObjectClassName$>: <$customSuperentity$> {
+class _<$swiftEntityClassNameWithoutModule$>: <$customSuperentity$> {
 
     <$if noninheritedAttributes.@count > 0$>
     struct Attributes {<$foreach Attribute noninheritedAttributes do$>
@@ -47,7 +47,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     }
 
     convenience init(managedObjectContext: NSManagedObjectContext!) {
-        let entity = _<$managedObjectClassName$>.entity(managedObjectContext)
+        let entity = _<$swiftEntityClassNameWithoutModule$>.entity(managedObjectContext)
         self.init(entity: entity, insertIntoManagedObjectContext: managedObjectContext)
     }
 
@@ -93,7 +93,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     }
 <$else$>
     @NSManaged
-    var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$>
+    var <$Relationship.name$>: <$Relationship.destinationEntity.swiftEntityClassNameWithoutModule$>
 
     // func validate<$Relationship.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
 <$endif$>
@@ -165,12 +165,12 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 
 <$foreach FetchedProperty noninheritedFetchedProperties do$>
     @NSManaged
-    let <$FetchedProperty.name$>: <$FetchedProperty.entity.managedObjectClassName$>[]
+    let <$FetchedProperty.name$>: <$FetchedProperty.entity.swiftEntityClassNameWithoutModule$>[]
 <$endforeach do$>
 }
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
-extension _<$managedObjectClassName$> {
+extension _<$swiftEntityClassNameWithoutModule$> {
 
     func add<$Relationship.name.initialCapitalString$>(objects: <$Relationship.immutableCollectionClassName$>) {
         self.<$Relationship.name$>Set().union<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
@@ -180,11 +180,11 @@ extension _<$managedObjectClassName$> {
         self.<$Relationship.name$>Set().minus<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
     }
 
-    func add<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
+    func add<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.swiftEntityClassNameWithoutModule$>!) {
         self.<$Relationship.name$>Set().addObject(value)
     }
 
-    func remove<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
+    func remove<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.swiftEntityClassNameWithoutModule$>!) {
         self.<$Relationship.name$>Set().removeObject(value)
     }
 

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -3,35 +3,35 @@
 
 import CoreData
 
-<$if noninheritedAttributes.@count > 0$>
-enum <$managedObjectClassName$>Attributes: String {<$foreach Attribute noninheritedAttributes do$>
-    case <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>
-}
-<$endif$>
-
-<$if noninheritedRelationships.@count > 0$>
-enum <$managedObjectClassName$>Relationships: String {<$foreach Relationship noninheritedRelationships do$>
-    case <$Relationship.name$> = "<$Relationship.name$>"<$endforeach do$>
-}
-<$endif$>
-
-<$if noninheritedFetchedProperties.@count > 0$>
-enum <$managedObjectClassName$>FetchedProperties: String {<$foreach FetchedProperty noninheritedFetchedProperties do$>
-    case <$FetchedProperty.name$> = "<$FetchedProperty.name$>"<$endforeach do$>
-}
-<$endif$>
-
-<$if hasUserInfoKeys$>
-enum <$managedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
-    case <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
-}
-<$endif$>
-
 @objc
 class _<$managedObjectClassName$>: <$customSuperentity$> {
 
+    <$if noninheritedAttributes.@count > 0$>
+    struct Attributes {<$foreach Attribute noninheritedAttributes do$>
+        static let <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>
+    }
+    <$endif$>
+
+    <$if noninheritedRelationships.@count > 0$>
+    struct Relationships {<$foreach Relationship noninheritedRelationships do$>
+        static let <$Relationship.name$> = "<$Relationship.name$>"<$endforeach do$>
+    }
+    <$endif$>
+
+    <$if noninheritedFetchedProperties.@count > 0$>
+    struct FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+        static let <$FetchedProperty.name$> = "<$FetchedProperty.name$>"<$endforeach do$>
+    }
+    <$endif$>
+
+    <$if hasUserInfoKeys$>
+    struct UserInfo {<$foreach UserInfo userInfoKeyValues do$>
+        static let <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
+    }
+    <$endif$>
+
     /// pragma mark - Class methods
-    
+
     <$if hasCustomSuperentity$>override <$endif$>class func entityName () -> String {
         return "<$name$>"
     }


### PR DESCRIPTION
Currently it is necessary to set the class name of an entity in your data model to the fully qualified Swift classname, plus its parent module, i.e. "MyThingKit.Account". This PR updates mogenerator to any modules from the front of the class name returned from `- [NSEntityDescription managedObjectClassName]` so that it just becomes "Account" in generated Swift output.

There might be a nicer way to come at this, and using `pathExtension` to achieve the module stripping isn't semantically great — but it works OK. 

I'm happy to update this PR based on any feedback.

This PR also includes the contents of #221. Feel free to merge it first, or this one in it's entirety — they both came from the same branch so it should be a clean merge.