### PR TITLE
Fix object type in replaceObjectInFooAtIndex:withObject:

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -273,7 +273,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
     [self setPrimitiveValue:tmpOrderedSet forKey:@"<$Relationship.name$>"];
     [self didChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:@"<$Relationship.name$>"];
 }
-- (void)replaceObjectIn<$Relationship.name.initialCapitalString$>AtIndex:(NSUInteger)idx withObject:(<$Relationship.immutableCollectionClassName$>*)value {
+- (void)replaceObjectIn<$Relationship.name.initialCapitalString$>AtIndex:(NSUInteger)idx withObject:(<$Relationship.destinationEntity.managedObjectClassName$>*)value {
     NSIndexSet* indexes = [NSIndexSet indexSetWithIndex:idx];
     [self willChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:@"<$Relationship.name$>"];
     NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self <$Relationship.name$>]];


### PR DESCRIPTION
The generated .m files should use the object class in
- (void)replaceObjectInFoosAtIndex:(NSUInteger)idx withObject:(Foo*)value

rather than the collection class (eg - (void)replaceObjectInFoosAtIndex:(NSUInteger)idx withObject:(NSOrderedSet*)value)

The .h file for the same method has the correct type.
