### PR TITLE
Explicitly comparing optionals with nil due to swift changes in beta 5

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -118,7 +118,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
         var result: AnyObject? = nil
         let results = managedObjectContext.executeFetchRequest(fetchRequest, error: &error)
 
-        if error {
+        if error != nil {
             outError.memory = error
         } else {
             switch results.count {
@@ -154,7 +154,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
         var error: NSError? = nil
         let results = managedObjectContext.executeFetchRequest(fetchRequest, error: &error)
 
-        if error {
+        if error != nil {
             outError.memory = error
         }
 


### PR DESCRIPTION
From the [release notes for Xcode 6 beta 5](http://adcdownload.apple.com//Developer_Tools/xcode_6_beta_5_za4gu6/xcode_6_beta_5__release_notes_.pdf):

> Optionals no longer conform to the BooleanType (formerly LogicValue) protocol, so they 
> may no longer be used in place of boolean expressions (they must be explicitly compared with 
> v != nil). This resolves confusion around Bool? and related types, makes code more 
> explicit about what test is expected, and is more consistent with the rest of the language. 

The swift template has to be changed to explicitly check optional Errors for nil.
