### PR TITLE
Using modern Objective C syntax: literals for arrays and dictionaries

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -216,9 +216,9 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	fetchRequest.sortDescriptors = sortDescriptors;
 	<$if indexedNoninheritedAttributes.@count > 0$>
 <$if TemplateVar.literals$>
-  NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
+	NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
 <$else$>
-  NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
+	NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
 <$endif$>
 	NSString *cacheName = [NSString stringWithFormat:@"mogenerator.<$managedObjectClassName$>.%@.<$Relationship.name$>.%@", indexedIDs, sortDescriptors];
 	<$endif$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -133,13 +133,21 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
 	<$if FetchRequest.hasBindings$>
+	<$if TemplateVar.literals$>
+	NSDictionary *substitutionVariables = @{<$foreach Binding FetchRequest.bindings doVar$>@"<$Binding.name$>": <$Binding.name$>_<$if BindingIndex < FetchRequest.bindings.@count - 1$>, <$endif$><$endforeach doVar$>};
+	<$else$>
 	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
 														<$foreach Binding FetchRequest.bindings do2$>
 														<$Binding.name$>_, @"<$Binding.name$>",
 														<$endforeach do2$>
 														nil];
+	<$endif$>
+	<$else$>
+	<$if TemplateVar.literals$>
+	NSDictionary *substitutionVariables = @{};
 	<$else$>
 	NSDictionary *substitutionVariables = [NSDictionary dictionary];
+	<$endif$>
 	<$endif$>
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];
@@ -186,13 +194,21 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
 	<$if FetchRequest.hasBindings$>
+	<$if TemplateVar.literals$>
+	NSDictionary *substitutionVariables = @{<$foreach Binding FetchRequest.bindings doVar$>@"<$Binding.name$>": <$Binding.name$>_<$if BindingIndex < FetchRequest.bindings.@count - 1$>, <$endif$><$endforeach doVar$>};
+	<$else$>
 	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
 														<$foreach Binding FetchRequest.bindings do2$>
 														<$Binding.name$>_, @"<$Binding.name$>",
 														<$endforeach do2$>
 														nil];
+	<$endif$>
+	<$else$>
+	<$if TemplateVar.literals$>
+	NSDictionary *substitutionVariables = @{};
 	<$else$>
 	NSDictionary *substitutionVariables = [NSDictionary dictionary];
+	<$endif$>
 	<$endif$>
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -235,11 +235,11 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	fetchRequest.predicate = [NSPredicate predicateWithFormat:@"<$Relationship.inverseRelationship.name$> <$if Relationship.inverseRelationship.isToMany$>CONTAINS<$else$>==<$endif$> %@", self];
 	fetchRequest.sortDescriptors = sortDescriptors;
 	<$if indexedNoninheritedAttributes.@count > 0$>
-  <$if TemplateVar.literals$>
+	<$if TemplateVar.literals$>
 	NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
-  <$else$>
+	<$else$>
 	NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
-  <$endif$>
+	<$endif$>
 	NSString *cacheName = [NSString stringWithFormat:@"mogenerator.<$managedObjectClassName$>.%@.<$Relationship.name$>.%@", indexedIDs, sortDescriptors];
 	<$endif$>
 	return [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -215,7 +215,11 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	fetchRequest.predicate = [NSPredicate predicateWithFormat:@"<$Relationship.inverseRelationship.name$> <$if Relationship.inverseRelationship.isToMany$>CONTAINS<$else$>==<$endif$> %@", self];
 	fetchRequest.sortDescriptors = sortDescriptors;
 	<$if indexedNoninheritedAttributes.@count > 0$>
-	NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
+<$if TemplateVar.literals$>
+  NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
+<$else$>
+  NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
+<$endif$>
 	NSString *cacheName = [NSString stringWithFormat:@"mogenerator.<$managedObjectClassName$>.%@.<$Relationship.name$>.%@", indexedIDs, sortDescriptors];
 	<$endif$>
 	return [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -235,11 +235,11 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 	fetchRequest.predicate = [NSPredicate predicateWithFormat:@"<$Relationship.inverseRelationship.name$> <$if Relationship.inverseRelationship.isToMany$>CONTAINS<$else$>==<$endif$> %@", self];
 	fetchRequest.sortDescriptors = sortDescriptors;
 	<$if indexedNoninheritedAttributes.@count > 0$>
-<$if TemplateVar.literals$>
+  <$if TemplateVar.literals$>
 	NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
-<$else$>
+  <$else$>
 	NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
-<$endif$>
+  <$endif$>
 	NSString *cacheName = [NSString stringWithFormat:@"mogenerator.<$managedObjectClassName$>.%@.<$Relationship.name$>.%@", indexedIDs, sortDescriptors];
 	<$endif$>
 	return [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -162,7 +162,11 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 				//	Nothing found matching the fetch request. That's cool, though: we'll just return nil.
 				break;
 			case 1:
+			<$if TemplateVar.literals$>
+				result = results.firstObject;
+			<$else$>
 				result = [results objectAtIndex:0];
+			<$endif$>
 				break;
 			default:
 				NSLog(@"WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, %lu found (substitutionVariables:%@, results:%@)",


### PR DESCRIPTION
Updated the machine.m template to use @[] and @{} literal syntax for arrays and dictionaries. 
These changes are enabled by the existing **literals** template-var.

Also, i think you can close https://github.com/rentzsch/mogenerator/pull/120 since these changes have been merged with https://github.com/rentzsch/mogenerator/pull/159 as far as i can tell.