### PR TITLE
Better optional property behavior and other enhancements to Swift support

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -52,6 +52,9 @@
 @interface NSObject (JustHereToSuppressIsOrderedNotImplementedCompilerWarning)
 - (BOOL)isOrdered;
 @end
+@interface NSPropertyDescription (swiftOptionality)
+- (NSString*)swiftOptionality;
+@end
 
 @interface NSString (camelCaseString)
 - (NSString*)camelCaseString;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -580,6 +580,39 @@ static NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFileName
 
 @end
 
+@implementation NSAttributeDescription (swiftOptionality)
+
+- (NSString *)swiftOptionality {
+    if(!self.optional && !self.defaultValue) {
+        // This property will start out as nil, so let's make it an implicit optional.
+        return @"!";
+    }
+    else {
+        return [super swiftOptionality];
+    }
+}
+
+@end
+
+@implementation NSRelationshipDescription (swiftOptionality)
+
+- (NSString *)swiftOptionality {
+    if (self.isToMany) {
+        // To-many relationships become "optional" by being empty, not by being nil.
+        return @"";
+    }
+    else {
+        NSString * optionality = [super swiftOptionality];
+        if([optionality isEqualToString:@""]) {
+            // This relationship will start off as nil, so let's make it an implicit optional.
+            optionality = @"!";
+        }
+        return optionality;
+    }
+}
+
+@end
+
 @implementation NSString (camelCaseString)
 - (NSString*)camelCaseString {
     NSArray *lowerCasedWordArray = [[self wordArray] arrayByMakingObjectsPerformSelector:@selector(lowercaseString)];

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -567,6 +567,19 @@ static NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFileName
 
 @end
 
+@implementation NSPropertyDescription (swiftOptionality)
+
+- (NSString*)swiftOptionality {
+    if(self.optional) {
+        return @"?";
+    }
+    else {
+        return @"";
+    }
+}
+
+@end
+
 @implementation NSString (camelCaseString)
 - (NSString*)camelCaseString {
     NSArray *lowerCasedWordArray = [[self wordArray] arrayByMakingObjectsPerformSelector:@selector(lowercaseString)];

--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,3 +1,5 @@
+import CoreData
+
 @objc(<$managedObjectClassName$>)
 class <$managedObjectClassName$>: _<$managedObjectClassName$> {
 

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -57,18 +57,18 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
     @NSManaged
-    let <$Attribute.name$>: NSNumber<$if Attribute.isOptional$>?<$endif$>
+    let <$Attribute.name$>: NSNumber<$Attribute.swiftOptionality$>
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: NSNumber<$if Attribute.isOptional$>?<$endif$>
+    var <$Attribute.name$>: NSNumber<$Attribute.swiftOptionality$>
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>
     @NSManaged
-    let <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
+    let <$Attribute.name$>: <$Attribute.objectAttributeType$><$Attribute.swiftOptionality$>
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
+    var <$Attribute.name$>: <$Attribute.objectAttributeType$><$Attribute.swiftOptionality$>
 <$endif$>
 <$endif$>
     // func validate<$Attribute.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
@@ -89,7 +89,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     }
 <$else$>
     @NSManaged
-    var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$><$if Relationship.isOptional$>?<$endif$>
+    var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$><$Relationship.swiftOptionality$>
 
     // func validate<$Relationship.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
 <$endif$>

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -81,6 +81,9 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     @NSManaged
     var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
 
+    var mutable<$Relationship.name.initialCapitalString$>: <$Relationship.mutableCollectionClassName$> {
+        return mutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>SetValueForKey("<$Relationship.name$>")
+    }
 <$else$>
     @NSManaged
     var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$><$if Relationship.isOptional$>?<$endif$>

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -81,8 +81,11 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     @NSManaged
     var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
 
-    var mutable<$Relationship.name.initialCapitalString$>: <$Relationship.mutableCollectionClassName$> {
-        return mutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>SetValueForKey("<$Relationship.name$>")
+    var <$Relationship.name$>Set: <$Relationship.mutableCollectionClassName$> {
+        willAccessValueForKey("<$Relationship.name$>")
+        let ret = mutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>SetValueForKey("<$Relationship.name$>")
+        didAccessValueForKey("<$Relationship.name$>")
+        return ret
     }
 <$else$>
     @NSManaged

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -57,10 +57,10 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
     @NSManaged
-    let <$Attribute.name$>: NSNumber?
+    let <$Attribute.name$>: NSNumber<$if Attribute.isOptional$>?<$endif$>
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: NSNumber?
+    var <$Attribute.name$>: NSNumber<$if Attribute.isOptional$>?<$endif$>
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>


### PR DESCRIPTION
This pull request includes several enhancements to Swift support.

The main thing it does is give `mogenerator` a more sophisticated and nuanced understanding of Swift optionals. Commit 4a11e53's log message explains the rationale, but in short:

* Optional properties are treated as Swift optionals (?).
* Certain non-optional properties that can be nil before the object is first saved are treated as implicitly unwrapped optionals (!).
* Non-optional properties that can't be nil unless you're doing weird, seemingly useless things are non-optional.

If you disagree with my rationale and think that `mogenerator` should allow Swift to handle all of Core Data's edge cases, I would still make non-optional properties implicitly unwrapped to reduce the cognitive burden on the programmer.

This pull request also includes two other small changes, which I apologize for including in an otherwise very focused branch:

* The human file templates now include an `import CoreData` statement (cb09202). This is not strictly *required* for a managed object subclass in Swift, but it's necessary for many extremely common operations, such as creating fetch requests or taking managed object contexts as parameters, so it seems more convenient to include it.
* Machine templates also include the `<relationshipName>Set` properties from the Objective-C templates, which access mutable proxies for relationships (48b1b9b and a39cddf). I've always found these incredibly handy.

If you don't like one of these, I won't be offended if you cherry-pick it out. Their commits don't include changes affecting the optional stuff.