### PR TITLE
Add support for deriving swift classes

### DIFF
--- a/NSEntityDescription+MOGenerator.h
+++ b/NSEntityDescription+MOGenerator.h
@@ -1,0 +1,16 @@
+//
+//  NSEntityDescription+MOGenerator.h
+//  mogenerator
+//
+//  Created by Rudolph van Graan on 02/09/2014.
+//
+//
+
+#import <CoreData/CoreData.h>
+
+@interface NSEntityDescription (MOGenerator)
+@property (nonatomic) BOOL isSwiftClass ;
+
+- (NSString *)derivedManagedObjectClassName;
+
+@end

--- a/NSEntityDescription+MOGenerator.m
+++ b/NSEntityDescription+MOGenerator.m
@@ -1,0 +1,51 @@
+//
+//  NSEntityDescription+MOGenerator.m
+//  mogenerator
+//
+//  Created by Rudolph van Graan on 02/09/2014.
+//
+//
+
+#import "NSEntityDescription+MOGenerator.h"
+#import <objc/runtime.h>
+
+static char const * const SwiftKey = "SwiftKeyTag";
+@implementation NSEntityDescription (MOGenerator)
+
+- (NSString *)derivedManagedObjectClassName {
+    if ([self isSwiftClass]) {
+        NSString *className = [self managedObjectClassName];
+        
+        NSError *error = NULL;
+        //Project.ClassName format
+        NSRegularExpression *regex = [NSRegularExpression
+                                      regularExpressionWithPattern:@"^(\\w+)\\.(\\w+)$"
+                                      options:NSRegularExpressionCaseInsensitive
+                                      error:&error];
+        NSArray *matches = [regex matchesInString:className options:0 range:NSMakeRange(0, [className length])];
+        if (matches.count == 1) {
+            NSTextCheckingResult *result = matches[0];
+            NSRange classNameRange = [result rangeAtIndex:2];
+            NSString *actualClassname = [className substringWithRange:classNameRange];
+            return actualClassname;
+        }
+    }
+    
+    return [self managedObjectClassName];
+}
+
+
+- (BOOL)isSwiftClass
+{
+    NSNumber *swiftClass = objc_getAssociatedObject(self, SwiftKey);
+    if (swiftClass) return [swiftClass boolValue];
+    return NO;
+}
+
+
+- (void)setIsSwiftClass:(BOOL )isSwiftClass {
+    NSNumber *swiftClass = [NSNumber numberWithBool:isSwiftClass];
+    objc_setAssociatedObject(self, SwiftKey, swiftClass, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -5,6 +5,7 @@
 
 #import "mogenerator.h"
 #import "RegexKitLite.h"
+#import "NSEntityDescription+MOGenerator.h"
 
 static NSString * const kTemplateVar = @"TemplateVar";
 NSString  *gCustomBaseClass;
@@ -965,7 +966,8 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
             }
         }
         nsenumerate ([model entitiesWithACustomSubclassInConfiguration:configuration verbose:NO], NSEntityDescription, entity) {
-            [entityFilesByName removeObjectForKey:[entity managedObjectClassName]];
+            entity.isSwiftClass = _swift;
+            [entityFilesByName removeObjectForKey:[entity derivedManagedObjectClassName]];
         }
         nsenumerate(entityFilesByName, NSSet, ophanedFiles) {
             nsenumerate(ophanedFiles, NSString, ophanedFile) {
@@ -1035,6 +1037,9 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
                         *machineHFiles = [NSMutableArray array];
         
         nsenumerate ([model entitiesWithACustomSubclassInConfiguration:configuration verbose:YES], NSEntityDescription, entity) {
+            entity.isSwiftClass = _swift;
+            NSLog(@"Processing entity %@ derived class %@",entity.managedObjectClassName,entity.derivedManagedObjectClassName);
+
             NSString *generatedMachineH = [machineH executeWithObject:entity sender:nil];
             NSString *generatedMachineM = [machineM executeWithObject:entity sender:nil];
             NSString *generatedHumanH = [humanH executeWithObject:entity sender:nil];
@@ -1046,13 +1051,14 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
             generatedHumanH = [generatedHumanH stringByReplacingOccurrencesOfRegex:@"([ \t]*(\n|\r|\r\n)){2,}" withString:@"\n\n"];
             generatedHumanM = [generatedHumanM stringByReplacingOccurrencesOfRegex:@"([ \t]*(\n|\r|\r\n)){2,}" withString:@"\n\n"];
             
-            NSString *entityClassName = [entity managedObjectClassName];
+            NSString *entityClassName = [entity derivedManagedObjectClassName];
             BOOL machineDirtied = NO;
             
             // Machine header files.
             NSString *extension = (_swift ? @"swift" : @"h");
             NSString *machineHFileName = [machineDir stringByAppendingPathComponent:
                                     [NSString stringWithFormat:@"_%@.%@", entityClassName, extension]];
+            NSLog(@"Processing entity %@ derived class %@ filename %@",entity.managedObjectClassName,entity.derivedManagedObjectClassName,machineHFileName);
             if (_listSourceFiles) {
                 [machineHFiles addObject:machineHFileName];
             } else {

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		79D2C05A0ACFBCB500F3F141 /* FoundationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 79D2C0580ACFBCB500F3F141 /* FoundationAdditions.m */; };
 		8DD76F9A0486AA7600D96B5E /* mogenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* mogenerator.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
+		AB10180419B5E2E100369851 /* NSEntityDescription+MOGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = AB10180319B5E2E100369851 /* NSEntityDescription+MOGenerator.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -168,6 +169,8 @@
 		79D2C0570ACFBCB500F3F141 /* FoundationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = FoundationAdditions.h; sourceTree = "<group>"; };
 		79D2C0580ACFBCB500F3F141 /* FoundationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = FoundationAdditions.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* mogenerator */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = mogenerator; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB10180219B5E2E100369851 /* NSEntityDescription+MOGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSEntityDescription+MOGenerator.h"; sourceTree = "<group>"; };
+		AB10180319B5E2E100369851 /* NSEntityDescription+MOGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSEntityDescription+MOGenerator.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +209,8 @@
 				7931E67910FE984F00175784 /* RegexKitLite.h */,
 				7931E67A10FE984F00175784 /* RegexKitLite.m */,
 				32A70AAB03705E1F00C91783 /* mogenerator_Prefix.pch */,
+				AB10180219B5E2E100369851 /* NSEntityDescription+MOGenerator.h */,
+				AB10180319B5E2E100369851 /* NSEntityDescription+MOGenerator.m */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -371,6 +376,9 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0600;
+			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "mogenerator" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -452,6 +460,7 @@
 				55200E960C49FEEA00018A42 /* DDCliApplication.m in Sources */,
 				55200E970C49FEEA00018A42 /* DDCliUtil.m in Sources */,
 				55200E980C49FEEA00018A42 /* DDGetoptLongParser.m in Sources */,
+				AB10180419B5E2E100369851 /* NSEntityDescription+MOGenerator.m in Sources */,
 				55200F9D0C4A2CA800018A42 /* DDCliParseException.m in Sources */,
 				7931E67B10FE984F00175784 /* RegexKitLite.m in Sources */,
 				457C26CD139A1EF900BF00DD /* MKCDAGNode.m in Sources */,
@@ -510,8 +519,8 @@
 		1DEB927908733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -519,7 +528,6 @@
 		1DEB927A08733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx;
 			};

--- a/templates/human.h.motemplate
+++ b/templates/human.h.motemplate
@@ -1,5 +1,5 @@
-#import "_<$managedObjectClassName$>.h"
+#import "_<$derivedManagedObjectClassName$>.h"
 
-@interface <$managedObjectClassName$> : _<$managedObjectClassName$> {}
+@interface <$derivedManagedObjectClassName$> : _<$derivedManagedObjectClassName$> {}
 // Custom logic goes here.
 @end

--- a/templates/human.m.motemplate
+++ b/templates/human.m.motemplate
@@ -1,14 +1,14 @@
-#import "<$managedObjectClassName$>.h"
+#import "<$derivedManagedObjectClassName$>.h"
 
 
-@interface <$managedObjectClassName$> ()
+@interface <$derivedManagedObjectClassName$> ()
 
 // Private interface goes here.
 
 @end
 
 
-@implementation <$managedObjectClassName$>
+@implementation <$derivedManagedObjectClassName$>
 
 // Custom logic goes here.
 

--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,5 +1,5 @@
 @objc(<$managedObjectClassName$>)
-class <$managedObjectClassName$>: _<$managedObjectClassName$> {
+public class <$managedObjectClassName$>: _<$managedObjectClassName$> {
 
 	// Custom logic goes here.
 

--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,5 +1,5 @@
-@objc(<$managedObjectClassName$>)
-public class <$managedObjectClassName$>: _<$managedObjectClassName$> {
+@objc(<$derivedManagedObjectClassName$>)
+public class <$derivedManagedObjectClassName$>: _<$derivedManagedObjectClassName$> {
 
 	// Custom logic goes here.
 

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -28,15 +28,15 @@ enum <$managedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyV
 <$endif$>
 
 @objc
-class _<$managedObjectClassName$>: <$customSuperentity$> {
+public class _<$managedObjectClassName$>: <$customSuperentity$> {
 
     // MARK: - Class methods
     
-    <$if hasCustomSuperentity$>override <$endif$>class func entityName () -> String {
+    <$if hasCustomSuperentity$>override <$endif$>public class func entityName () -> String {
         return "<$name$>"
     }
 
-    <$if hasCustomSuperentity$>override <$endif$>class func entity(managedObjectContext: NSManagedObjectContext!) -> NSEntityDescription! {
+    <$if hasCustomSuperentity$>override <$endif$>public class func entity(managedObjectContext: NSManagedObjectContext!) -> NSEntityDescription! {
         return NSEntityDescription.entityForName(self.entityName(), inManagedObjectContext: managedObjectContext);
     }
 

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -4,31 +4,31 @@
 import CoreData
 
 <$if noninheritedAttributes.@count > 0$>
-enum <$managedObjectClassName$>Attributes: String {<$foreach Attribute noninheritedAttributes do$>
+enum <$derivedManagedObjectClassName$>Attributes: String {<$foreach Attribute noninheritedAttributes do$>
     case <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>
 }
 <$endif$>
 
 <$if noninheritedRelationships.@count > 0$>
-enum <$managedObjectClassName$>Relationships: String {<$foreach Relationship noninheritedRelationships do$>
+enum <$derivedManagedObjectClassName$>Relationships: String {<$foreach Relationship noninheritedRelationships do$>
     case <$Relationship.name$> = "<$Relationship.name$>"<$endforeach do$>
 }
 <$endif$>
 
 <$if noninheritedFetchedProperties.@count > 0$>
-enum <$managedObjectClassName$>FetchedProperties: String {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+enum <$derivedManagedObjectClassName$>FetchedProperties: String {<$foreach FetchedProperty noninheritedFetchedProperties do$>
     case <$FetchedProperty.name$> = "<$FetchedProperty.name$>"<$endforeach do$>
 }
 <$endif$>
 
 <$if hasUserInfoKeys$>
-enum <$managedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
+enum <$derivedManagedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
     case <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
 }
 <$endif$>
 
 @objc
-public class _<$managedObjectClassName$>: <$customSuperentity$> {
+public class _<$derivedManagedObjectClassName$>: <$customSuperentity$> {
 
     // MARK: - Class methods
     
@@ -47,7 +47,7 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
     }
 
     convenience init(managedObjectContext: NSManagedObjectContext!) {
-        let entity = _<$managedObjectClassName$>.entity(managedObjectContext)
+        let entity = _<$derivedManagedObjectClassName$>.entity(managedObjectContext)
         self.init(entity: entity, insertIntoManagedObjectContext: managedObjectContext)
     }
 
@@ -60,7 +60,7 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
     let <$Attribute.name$>: NSNumber?
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: NSNumber?
+    public var <$Attribute.name$>: NSNumber?
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>
@@ -68,7 +68,7 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
     let <$Attribute.name$>: <$Attribute.objectAttributeType$>
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: <$Attribute.objectAttributeType$>
+    public var <$Attribute.name$>: <$Attribute.objectAttributeType$>
 <$endif$>
 <$endif$>
     // func validate<$Attribute.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
@@ -79,7 +79,7 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
     @NSManaged
-    var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
+    public var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
 
     func <$Relationship.name$>Set() -> <$Relationship.mutableCollectionClassName$>! {
         self.willAccessValueForKey("<$Relationship.name$>")
@@ -93,7 +93,7 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
     }
 <$else$>
     @NSManaged
-    var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$>
+    public var <$Relationship.name$>: <$Relationship.destinationEntity.derivedManagedObjectClassName$>
 
     // func validate<$Relationship.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
 <$endif$>
@@ -165,12 +165,12 @@ public class _<$managedObjectClassName$>: <$customSuperentity$> {
 
 <$foreach FetchedProperty noninheritedFetchedProperties do$>
     @NSManaged
-    let <$FetchedProperty.name$>: [<$FetchedProperty.entity.managedObjectClassName$>]
+    let <$FetchedProperty.name$>: [<$FetchedProperty.entity.derivedManagedObjectClassName$>]
 <$endforeach do$>
 }
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
-extension _<$managedObjectClassName$> {
+extension _<$derivedManagedObjectClassName$> {
 
     func add<$Relationship.name.initialCapitalString$>(objects: <$Relationship.immutableCollectionClassName$>) {
         self.<$Relationship.name$>Set().union<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
@@ -180,11 +180,11 @@ extension _<$managedObjectClassName$> {
         self.<$Relationship.name$>Set().minus<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
     }
 
-    func add<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
+    func add<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.derivedManagedObjectClassName$>!) {
         self.<$Relationship.name$>Set().addObject(value)
     }
 
-    func remove<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
+    func remove<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.derivedManagedObjectClassName$>!) {
         self.<$Relationship.name$>Set().removeObject(value)
     }
 


### PR DESCRIPTION
This is a patch to correctly derive the Swift classnames from the fully qualified names in the data model.
It also includes changes to the templates to make the classes and members public so that they can be accessed from test targets.