### PR TITLE
Update init(entity:insert…) override to match Beta 7 signature

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -42,7 +42,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 
     // MARK: - Life cycle methods
 
-    override init(entity: NSEntityDescription!, insertIntoManagedObjectContext context: NSManagedObjectContext!) {
+    override init(entity: NSEntityDescription, insertIntoManagedObjectContext context: NSManagedObjectContext!) {
         super.init(entity: entity, insertIntoManagedObjectContext: context)
     }
 


### PR DESCRIPTION
The entity parameter to `init(entity:insertIntoManagedObjectContext:)` is no longer optional in beta 7. This pull request updates mogenerator to match.
