### PR TITLE
Allow multiple devs on same machine to use mogenerator

### DIFF
--- a/build-mogenerator-Info-plist.sh
+++ b/build-mogenerator-Info-plist.sh
@@ -1,4 +1,4 @@
-rm -f /tmp/mogenerator-Info.plist
+rm -f $TMPDIR/mogenerator-Info.plist
 /usr/libexec/PlistBuddy \
 	-c "Clear" \
 	-c "Import :human.h.motemplate templates/human.h.motemplate" \
@@ -7,4 +7,4 @@ rm -f /tmp/mogenerator-Info.plist
 	-c "Import :machine.h.motemplate templates/machine.h.motemplate" \
 	-c "Import :machine.m.motemplate templates/machine.m.motemplate" \
 	-c "Import :machine.swift.motemplate templates/machine.swift.motemplate" \
-	/tmp/mogenerator-Info.plist
+	$TMPDIR/mogenerator-Info.plist

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -371,6 +371,8 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "mogenerator" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -479,7 +481,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"/tmp/mogenerator-Info.plist",
+					"$TMPDIR/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";
@@ -500,7 +502,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"/tmp/mogenerator-Info.plist",
+					"$TMPDIR/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";


### PR DESCRIPTION
When more than one developer is building on the same machine, an issue existed where the build would fail.
The mogenerator-Info.plist file would be owned by a different user and could not be removed. This patch makes sure that a per-user temp dir is being used.

Signed-off-by: Annard Brouwer a.brouwer@qsrinternational.com
