### PR TITLE
Generate scalar properties for primitive types

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -53,6 +53,13 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>
+<$if TemplateVar.scalars and Attribute.hasScalarAttributeType and !Attribute.isOptional$>
+<$if Attribute.isReadonly$>
+@property (atomic, readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>;
+<$else$>
+@property (atomic) <$Attribute.scalarAttributeType$> <$Attribute.name$>;
+<$endif$>
+<$else$>
 <$if TemplateVar.arc$>
 <$if Attribute.isReadonly$>
 @property (nonatomic, strong, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
@@ -74,6 +81,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 @property (atomic) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 <$endif$>
 //- (BOOL)validate<$Attribute.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
@@ -141,11 +149,16 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
 <$foreach Attribute noninheritedAttributesSansType do$>
 <$if Attribute.hasDefinedAttributeType$>
+<$if TemplateVar.scalars and Attribute.hasScalarAttributeType and !Attribute.isOptional$>
+- (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
+- (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.scalarAttributeType$>)value_;
+<$else$>
 - (<$Attribute.objectAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>)value;
 <$if Attribute.hasScalarAttributeType$>
 - (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
+<$endif$>
 <$endif$>
 <$endif$>
 <$endforeach do$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -67,7 +67,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 @dynamic <$Attribute.name$>;
 
-<$if Attribute.hasScalarAttributeType$>
+<$if Attribute.hasScalarAttributeType and (!TemplateVar.scalars or Attribute.isOptional)$>
 
 - (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value {
 	NSNumber *result = [self <$Attribute.name$>];

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -57,10 +57,10 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
     @NSManaged
-    let <$Attribute.name$>: NSNumber?
+    let <$Attribute.name$>: <$if TemplateVar.scalars and !Attribute.isOptional$><$Attribute.scalarAttributeType$><$else$>NSNumber<$if Attribute.isOptional$>?<$endif$><$endif$>
 <$else$>
     @NSManaged
-    var <$Attribute.name$>: NSNumber?
+    var <$Attribute.name$>: <$if TemplateVar.scalars and !Attribute.isOptional$><$Attribute.scalarAttributeType$><$else$>NSNumber<$if Attribute.isOptional$>?<$endif$><$endif$>
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>


### PR DESCRIPTION
This introduces a "scalars" boolean template variable for both the Objective-C and the Swift templates.

When true, property declarations for non-optional attributes with hasScalarAttributeType will use the appropriate scalar type and, in the case of Objective-C, omit the generated *Value accessors.

Additionally (when scalars=false), generated NSNumber properties for hasScalarAttributeType attributes in the Swift template will only be optional when the attribute is optional, just as it is for Strings or NSDate etc (if that's contentious then let me know, I just don't know of a reason why NSNumber should be any different).

This change may go some way to easing the pain described in #219, but Swift *Value accessors are a separate issue that probably still needs to be addressed.

Compatibility: Core Data support for scalar properties appeared in iOS 5 and OS X 10.7, though my own testing is limited to iOS 8 and 10.10.