### PR TITLE
Swift: Make generated machine classes and their attributes public.

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -27,7 +27,7 @@ enum <$managedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyV
 }
 <$endif$>
 
-@objc
+@objc public
 class _<$managedObjectClassName$>: <$customSuperentity$> {
 
     // MARK: - Class methods
@@ -56,18 +56,18 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$if Attribute.hasDefinedAttributeType$>
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
-    @NSManaged
+    @NSManaged public
     let <$Attribute.name$>: NSNumber?
 <$else$>
-    @NSManaged
+    @NSManaged public
     var <$Attribute.name$>: NSNumber?
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>
-    @NSManaged
+    @NSManaged public
     let <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
 <$else$>
-    @NSManaged
+    @NSManaged public
     var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
 <$endif$>
 <$endif$>
@@ -78,11 +78,11 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
     // MARK: - Relationships
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
-    @NSManaged
+    @NSManaged public
     var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
 
 <$else$>
-    @NSManaged
+    @NSManaged public
     var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$><$if Relationship.isOptional$>?<$endif$>
 
     // func validate<$Relationship.name.initialCapitalString$>(value: AutoreleasingUnsafePointer<AnyObject>, error: NSErrorPointer) {}
@@ -154,7 +154,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$endforeach do$>
 
 <$foreach FetchedProperty noninheritedFetchedProperties do$>
-    @NSManaged
+    @NSManaged public
     let <$FetchedProperty.name$>: [<$FetchedProperty.entity.managedObjectClassName$>]
 <$endforeach do$>
 }


### PR DESCRIPTION
Swift classes in frameworks/dynamic libraries are inaccessible to clients unless they and their public API are declared `public`. A class may not be made public unless its superclass is also public.

So: If you want to expose `MyMogeneratedClass` in a dynamic library, you must also declare `_MyMogeneratedClass` `public`. This requires hand-editing `_MyMogeneratedClass.swift`, which defeats the purpose of machine-generated classes.

This revision adds the `public` qualifier to the class and `@NSManaged` properties in `machine.swift.motemplate`.

## Bugs

A subtler implementation might add a command-line argument to suppress or otherwise refine the use of `public`. However:

1. Nobody needs more command-line arguments. Ever.
2. Risk of accidental collisions between framework and client code is small (absent in Swift).
3. `@objc` methods are introspectable whether defined in Swift or Objective-C. “Unauthorized” access to private API is a ship that sailed thirty years ago. Details too numerous to state here.
4. See the next section: You can’t unit-test a mogenerated class without making it `public`.

## Testing

The `rake`-mediated test suite in `test/` passes. In my haste, I haven’t figured out whether `MogenSwiftTest` has anything to do with the integrity of the product. Possibly not, or not recently, as it relies on the WWDC dialect of Swift rather than that in Xcode 6.1.

With modifications (which included a lot of `public` tags to expose the classes under test to the test module), the Test action yields a pass on all tests.