### PR TITLE
Swift 1.2 support

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -79,7 +79,7 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
     @NSManaged
-    var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
+    var <$Relationship.name$>: Set<<$Relationship.destinationEntity.managedObjectClassName$>>
 
 <$else$>
     @NSManaged
@@ -162,28 +162,20 @@ class _<$managedObjectClassName$>: <$customSuperentity$> {
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
 extension _<$managedObjectClassName$> {
 
-    func add<$Relationship.name.initialCapitalString$>(objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.union<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
-        self.<$Relationship.name$> = mutable.copy() as NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
+    func add<$Relationship.name.initialCapitalString$>(objects: Set<<$Relationship.destinationEntity.managedObjectClassName$>>) {
+		self.<$Relationship.name$> = self.<$Relationship.name$>.union(objects)
     }
 
-    func remove<$Relationship.name.initialCapitalString$>(objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.minus<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set(objects)
-        self.<$Relationship.name$> = mutable.copy() as NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
+    func remove<$Relationship.name.initialCapitalString$>(objects: Set<<$Relationship.destinationEntity.managedObjectClassName$>>) {
+		self.<$Relationship.name$> = self.<$Relationship.name$>.subtract(objects)
     }
 
     func add<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.addObject(value)
-        self.<$Relationship.name$> = mutable.copy() as NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
+		self.<$Relationship.name$>.insert(value)
     }
 
     func remove<$Relationship.name.initialCapitalString$>Object(value: <$Relationship.destinationEntity.managedObjectClassName$>!) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.removeObject(value)
-        self.<$Relationship.name$> = mutable.copy() as NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
+		self.<$Relationship.name$>.remove(value)
     }
 
 }


### PR DESCRIPTION
Adjusted the Swift template to support Swift v1.2.

Replaced NSSet with Set<<$Relationship.destinationEntity.managedObjectClassName$>>.

**Not sure this is the way you want this solved, but I just updated the template, but there is no support for Swift versions before 1.2 now.**