### PR TITLE
Support for protocols for Swift and Objective-C

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -22,9 +22,11 @@
 - (BOOL)hasCustomClass;
 - (BOOL)hasSuperentity;
 - (BOOL)hasCustomSuperentity;
+- (BOOL)hasCustomProtocol;
 - (BOOL)hasAdditionalHeaderFile;
 - (NSString*)customSuperentity;
 - (NSString*)forcedCustomBaseClass;
+- (NSString*)customProtocol;
 - (NSString*)additionalHeaderFileName;
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_;
 - (NSArray*)prettyFetchRequests;
@@ -65,6 +67,7 @@
     NSString              *baseClass;
     NSString              *baseClassImport;
     NSString              *baseClassForce;
+    NSString              *protocol;
     NSString              *includem;
     NSString              *includeh;
     NSString              *templatePath;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -10,6 +10,7 @@ static NSString * const kTemplateVar = @"TemplateVar";
 NSString  *gCustomBaseClass;
 NSString  *gCustomBaseClassImport;
 NSString  *gCustomBaseClassForced;
+NSString  *gCustomProtocol;
 BOOL       gSwift;
 
 static NSString *const kAttributeValueScalarTypeKey = @"attributeValueScalarType";
@@ -150,6 +151,11 @@ static NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFileName
     }
 }
 
+- (BOOL)hasCustomProtocol {
+    NSString *customProtocol = gCustomProtocol;
+    return customProtocol != nil;
+}
+
 - (BOOL)hasAdditionalHeaderFile {
     return [[[self userInfo] allKeys] containsObject:kAdditionalHeaderFileNameKey];
 }
@@ -171,6 +177,11 @@ static NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFileName
     NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:@"mogenerator.customBaseClass"];
     return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
 }
+
+- (NSString*)customProtocol {
+    return gCustomProtocol;
+}
+
 /** @TypeInfo NSAttributeDescription */
 - (NSArray*)noninheritedAttributes {
     NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
@@ -674,6 +685,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         {@"base-class-force",   0,     DDGetoptRequiredArgument},
         // For compatibility:
         {@"baseClass",          0,     DDGetoptRequiredArgument},
+        {@"protocol",           0,     DDGetoptRequiredArgument},
         {@"includem",           0,     DDGetoptRequiredArgument},
         {@"includeh",           0,     DDGetoptRequiredArgument},
         {@"template-path",      0,     DDGetoptRequiredArgument},
@@ -730,6 +742,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
            "--base-class-force CLASS  Same as --base-class except will force all entities to\n"
            "                          have the specified base class. Even if a super entity\n"
            "                          exists\n"
+           "--protocol PROTOCOL       Custom protocol\n"
            "--includem FILE           Generate aggregate include file for .m files for both\n"
            "                          human and machine generated source files\n"
            "--includeh FILE           Generate aggregate include file for .h files for human\n"
@@ -941,6 +954,10 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
     } else {
         gCustomBaseClass = [baseClass retain];
         gCustomBaseClassImport = [baseClassImport retain];
+    }
+    
+    if (protocol) {
+        gCustomProtocol = protocol;
     }
 
     NSString * mfilePath = includem;

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -52,7 +52,7 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
  * <$userInfo.discussion$>
  */
 <$endif$>
-@interface _<$managedObjectClassName$> : <$customSuperentity$> {}
+@interface _<$managedObjectClassName$> : <$customSuperentity$><$if hasCustomProtocol $><<$customProtocol$>><$endif$> {}
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -3,6 +3,8 @@
 
 import CoreData
 
+<$if hasCustomBaseCaseImport$>import <$baseClassImport$><$endif$>
+
 <$if noninheritedAttributes.@count > 0$>
 enum <$managedObjectClassName$>Attributes: String {<$foreach Attribute noninheritedAttributes do$>
     case <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -30,7 +30,7 @@ enum <$managedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyV
 <$endif$>
 
 @objc
-class _<$managedObjectClassName$>: <$customSuperentity$> {
+class _<$managedObjectClassName$>: <$customSuperentity$><$if hasCustomProtocol $>,<$customProtocol$><$endif$> {
 
     // MARK: - Class methods
     


### PR DESCRIPTION
I had the requirement to implement a protocol to the NSManagedObjects providing the method "entityName ". I thought it would be handsome if mogenerator could generate classes with a given protocol, so it would not be necessary to create an extra base class for only this purpose.

Also it would also be possible to create a default protocol for the mogenerator methods. What do you think?
