### PR TITLE
Fix: treat non-existant XML attributes correctly

### DIFF
--- a/momcom/NSPropertyDescription+momcom.m
+++ b/momcom/NSPropertyDescription+momcom.m
@@ -19,6 +19,9 @@
     }
 
     NSPropertyDescription *propertyDescription = [[self alloc] init];
+    BOOL optional = NO;
+    BOOL transient = NO;
+    BOOL indexed = NO;
     BOOL syncable = NO;
 
     for (NSXMLNode *xmlAttribute in [xmlNode attributes]) {
@@ -27,11 +30,11 @@
         if ([attributeName isEqualToString:@"name"]) {
             [propertyDescription setName:attributeString];
         } else if ([attributeName isEqualToString:@"optional"]) {
-            [propertyDescription setOptional:[attributeString isEqualToString:@"YES"]];
+            optional = [attributeString isEqualToString:@"YES"];
         } else if ([attributeName isEqualToString:@"transient"]) {
-            [propertyDescription setTransient:[attributeString isEqualToString:@"YES"]];
+            transient = [attributeString isEqualToString:@"YES"];
         } else if ([attributeName isEqualToString:@"indexed"]) {
-            [propertyDescription setIndexed:[attributeString isEqualToString:@"YES"]];
+            indexed = [attributeString isEqualToString:@"YES"];
         } else if ([attributeName isEqualToString:@"syncable"]) {
             syncable = [attributeString isEqualToString:@"YES"];
         } else if ([attributeName isEqualToString:@"versionHashModifier"]) {
@@ -40,6 +43,11 @@
             [propertyDescription setRenamingIdentifier:attributeString];
         }
     }
+    
+    [propertyDescription setOptional:optional];
+    [propertyDescription setTransient:transient];
+    [propertyDescription setIndexed:indexed];
+    
 
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
 


### PR DESCRIPTION
Xcode omits the optional attribute in its XML model output if
it is set to not-optional, but `NSPropertyDescription.optional`
defaults to `YES`.
To be on the safe side I decided to treat all Booleans the same.
Currenlty only `optional` was affected, because it's the only
attribute which default is `YES`.

That should fix issue #286