### PR TITLE
Update build-mogenerator-Info.plist.sh to use DERIVED_FILE_DIR instead of TMPDIR

### DIFF
--- a/build-mogenerator-Info-plist.sh
+++ b/build-mogenerator-Info-plist.sh
@@ -1,4 +1,5 @@
-rm -f $TMPDIR/mogenerator-Info.plist
+TMPDIR=${DERIVED_FILE_DIR}
+rm -f "${TMPDIR}/mogenerator-Info.plist"
 /usr/libexec/PlistBuddy \
 	-c "Clear" \
 	-c "Import :human.h.motemplate templates/human.h.motemplate" \
@@ -7,4 +8,4 @@ rm -f $TMPDIR/mogenerator-Info.plist
 	-c "Import :machine.h.motemplate templates/machine.h.motemplate" \
 	-c "Import :machine.m.motemplate templates/machine.m.motemplate" \
 	-c "Import :machine.swift.motemplate templates/machine.swift.motemplate" \
-	$TMPDIR/mogenerator-Info.plist
+	"${TMPDIR}/mogenerator-Info.plist"

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -439,8 +439,15 @@
 			files = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/templates/human.m.motemplate",
+				"$(SRCROOT)/templates/human.h.motemplate",
+				"$(SRCROOT)/templates/human.swift.motemplate",
+				"$(SRCROOT)/templates/machine.h.motemplate",
+				"$(SRCROOT)/templates/machine.m.motemplate",
+				"$(SRCROOT)/templates/machine.swift.motemplate",
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/motemplate-Info.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"$TMPDIR/mogenerator-Info.plist",
+					"$(DERIVED_FILE_DIR)/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";
@@ -552,7 +552,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"$TMPDIR/mogenerator-Info.plist",
+					"$(DERIVED_FILE_DIR)/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";


### PR DESCRIPTION
TMPDIR is not well-defined, but DERIVED_FILE_DIR is during an Xcode build. 
Also, make sure paths are quoted.