### PR TITLE
Default to --v2 arguments.

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -76,7 +76,6 @@
     BOOL                  _listSourceFiles;
     BOOL                  _orphaned;
     BOOL                  _swift;
-    BOOL                  _v2;
     NSMutableDictionary   *templateVar;
 }
 @end

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -685,8 +685,6 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
     DDGetoptOption optionTable[] =
     {
         // Long                 Short  Argument options
-        {@"v2",                 '2',   DDGetoptNoArgument},
-
         {@"model",              'm',   DDGetoptRequiredArgument},
         {@"configuration",      'C',   DDGetoptRequiredArgument},
         {@"base-class",         0,     DDGetoptRequiredArgument},
@@ -726,11 +724,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
            "Typical Use\n"
            "-----------\n"
            "\n"
-           "$ mogenerator --v2 --model MyModel.xcdatamodeld --output-dir MyModel\n"
-           "\n"
-           "The --v2 argument tells mogenerator to use modern Objective-C (ARC,\n"
-           "Objective-C literals, modules). Otherwise mogenerator will generate old-style\n"
-           "Objective-C.\n"
+           "$ mogenerator --model MyModel.xcdatamodeld --output-dir MyModel\n"
            "\n"
            "Use the --model argument to supply the required data model file.\n"
            "\n"
@@ -956,13 +950,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         printf("mogenerator 1.29. By Jonathan 'Wolf' Rentzsch + friends.\n");
         return EXIT_SUCCESS;
     }
-
-    if (_v2) {
-        [templateVar setObject:@YES forKey:@"arc"];
-        [templateVar setObject:@YES forKey:@"literals"];
-        [templateVar setObject:@YES forKey:@"modules"];
-    }
-
+    
     gSwift = _swift;
 
     if (baseClassForce) {

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -1,7 +1,8 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to <$managedObjectClassName$>.h instead.
 
-<$if TemplateVar.modules$>@import CoreData;<$else$>#import <CoreData/CoreData.h><$endif$>
+@import CoreData;
+
 <$if hasCustomSuperentity$><$if hasSuperentity$>#import "<$customSuperentity$>.h"
 <$else$><$if hasCustomBaseCaseImport$>#import <$baseClassImport$><$else$>#import "<$customSuperentity$>.h"<$endif$><$endif$><$endif$>
 
@@ -11,25 +12,25 @@
 
 <$if noninheritedAttributes.@count > 0$>
 extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>
-	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Attribute.name$>;<$endforeach do$>
+	__unsafe_unretained NSString *<$Attribute.name$>;<$endforeach do$>
 } <$managedObjectClassName$>Attributes;
 <$endif$>
 
 <$if noninheritedRelationships.@count > 0$>
 extern const struct <$managedObjectClassName$>Relationships {<$foreach Relationship noninheritedRelationships do$>
-	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$Relationship.name$>;<$endforeach do$>
+	__unsafe_unretained NSString *<$Relationship.name$>;<$endforeach do$>
 } <$managedObjectClassName$>Relationships;
 <$endif$>
 
 <$if noninheritedFetchedProperties.@count > 0$>
 extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
-	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$FetchedProperty.name$>;<$endforeach do$>
+	__unsafe_unretained NSString *<$FetchedProperty.name$>;<$endforeach do$>
 } <$managedObjectClassName$>FetchedProperties;
 <$endif$>
 
 <$if hasUserInfoKeys$>
 extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userInfoKeyValues do$>
-	<$if TemplateVar.arc$>__unsafe_unretained<$endif$> NSString *<$UserInfo.key$>;<$endforeach do$>
+	__unsafe_unretained NSString *<$UserInfo.key$>;<$endforeach do$>
 } <$managedObjectClassName$>UserInfo;
 <$endif$>
 
@@ -67,18 +68,10 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
  */
 <$endif$>
 <$if Attribute.hasDefinedAttributeType$>
-<$if TemplateVar.arc$>
 <$if Attribute.isReadonly$>
 @property (nonatomic, strong, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
 @property (nonatomic, strong) <$Attribute.objectAttributeType$> <$Attribute.name$>;
-<$endif$>
-<$else$>
-<$if Attribute.isReadonly$>
-@property (nonatomic, retain, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
-<$else$>
-@property (nonatomic, retain) <$Attribute.objectAttributeType$> <$Attribute.name$>;
-<$endif$>
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
@@ -102,18 +95,10 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
  */
 <$endif$>
 <$if Relationship.isToMany$>
-<$if TemplateVar.arc$>
 @property (nonatomic, strong) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
-<$else$>
-@property (nonatomic, retain) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
-<$endif$>
 - (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
 <$else$>
-<$if TemplateVar.arc$>
 @property (nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
-<$else$>
-@property (nonatomic, retain) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
-<$endif$>
 //- (BOOL)validate<$Relationship.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
 <$endif$>
 <$endforeach do$>

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -76,7 +76,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 <$if ! Attribute.isReadonly$>
 - (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
-	[self set<$Attribute.name.initialCapitalString$>:<$if TemplateVar.literals$>@(value_)<$else$>[NSNumber <$Attribute.scalarFactoryMethodName$>value_]<$endif$>];
+	[self set<$Attribute.name.initialCapitalString$>:@(value_)];
 }
 <$endif$>
 
@@ -87,7 +87,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 }
 
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_ {
-	[self setPrimitive<$Attribute.name.initialCapitalString$>:<$if TemplateVar.literals$>@(value_)<$else$>[NSNumber <$Attribute.scalarFactoryMethodName$>value_]<$endif$>];
+	[self setPrimitive<$Attribute.name.initialCapitalString$>:@(value_)];
 }
 <$endif$>
 <$endif$>
@@ -135,21 +135,9 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
 	<$if FetchRequest.hasBindings$>
-	<$if TemplateVar.literals$>
 	NSDictionary *substitutionVariables = @{<$foreach Binding FetchRequest.bindings doVar$>@"<$Binding.name$>": <$Binding.name$>_<$if BindingIndex < FetchRequest.bindings.@count - 1$>, <$endif$><$endforeach doVar$>};
 	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
-														<$foreach Binding FetchRequest.bindings do2$>
-														<$Binding.name$>_, @"<$Binding.name$>",
-														<$endforeach do2$>
-														nil];
-	<$endif$>
-	<$else$>
-	<$if TemplateVar.literals$>
 	NSDictionary *substitutionVariables = @{};
-	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionary];
-	<$endif$>
 	<$endif$>
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];
@@ -164,11 +152,7 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 				//	Nothing found matching the fetch request. That's cool, though: we'll just return nil.
 				break;
 			case 1:
-			<$if TemplateVar.literals$>
 				result = results.firstObject;
-			<$else$>
-				result = [results objectAtIndex:0];
-			<$endif$>
 				break;
 			default:
 				NSLog(@"WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, %lu found (substitutionVariables:%@, results:%@)",
@@ -200,21 +184,9 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 
 	NSManagedObjectModel *model = [[moc_ persistentStoreCoordinator] managedObjectModel];
 	<$if FetchRequest.hasBindings$>
-	<$if TemplateVar.literals$>
 	NSDictionary *substitutionVariables = @{<$foreach Binding FetchRequest.bindings doVar$>@"<$Binding.name$>": <$Binding.name$>_<$if BindingIndex < FetchRequest.bindings.@count - 1$>, <$endif$><$endforeach doVar$>};
 	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionaryWithObjectsAndKeys:
-														<$foreach Binding FetchRequest.bindings do2$>
-														<$Binding.name$>_, @"<$Binding.name$>",
-														<$endforeach do2$>
-														nil];
-	<$endif$>
-	<$else$>
-	<$if TemplateVar.literals$>
 	NSDictionary *substitutionVariables = @{};
-	<$else$>
-	NSDictionary *substitutionVariables = [NSDictionary dictionary];
-	<$endif$>
 	<$endif$>
 	NSFetchRequest *fetchRequest = [model fetchRequestFromTemplateWithName:@"<$FetchRequest.name$>"
 													 substitutionVariables:substitutionVariables];
@@ -232,16 +204,11 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 <$if Relationship.isToMany$>
 - (NSFetchedResultsController*)new<$Relationship.name.initialCapitalString$>FetchedResultsControllerWithSortDescriptors:(NSArray*)sortDescriptors {
 	NSFetchRequest *fetchRequest = [NSFetchRequest new];
-	<$if !TemplateVar.arc$>[fetchRequest autorelease];<$endif$>
 	fetchRequest.entity = [NSEntityDescription entityForName:@"<$Relationship.destinationEntity.name$>" inManagedObjectContext:self.managedObjectContext];
 	fetchRequest.predicate = [NSPredicate predicateWithFormat:@"<$Relationship.inverseRelationship.name$> <$if Relationship.inverseRelationship.isToMany$>CONTAINS<$else$>==<$endif$> %@", self];
 	fetchRequest.sortDescriptors = sortDescriptors;
 	<$if indexedNoninheritedAttributes.@count > 0$>
-	<$if TemplateVar.literals$>
 	NSArray *indexedIDs = @[<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$><$if AttributeIndex < indexedNoninheritedAttributes.@count - 1$>, <$endif$><$endforeach do$>];
-	<$else$>
-	NSArray *indexedIDs = [NSArray arrayWithObjects:<$foreach Attribute indexedNoninheritedAttributes do$>self.<$Attribute.name$>, <$endforeach do$>nil];
-	<$endif$>
 	NSString *cacheName = [NSString stringWithFormat:@"mogenerator.<$managedObjectClassName$>.%@.<$Relationship.name$>.%@", indexedIDs, sortDescriptors];
 	<$endif$>
 	return [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest
@@ -316,5 +283,3 @@ const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserIn
 }
 @end
 <$endif$><$endif$><$endforeach do$>
-
-

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -12,40 +12,20 @@ run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator cle
 run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator'
 mogenPath = "#{built_products_dir}/mogenerator"
 
-def gen_and_compile(desc, mogenPath, extra_mogen_args, extra_gcc_args)
+def gen_and_compile(desc, mogenPath, extra_mogen_args, extra_llvm_args)
   puts "*** Testing #{desc}"
   ENV['MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS'] = '1'
   run_or_die "#{mogenPath.gsub(/ /, '\\ ')} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
   run_or_die 'cp HumanMO.h HumanMO.m MyProtocol.h TestProtocol.m MOs'
-  run_or_die "clang -o testbin test.m MyBaseClass.m Gender.m MOs/*.m -I\"#{Dir.pwd}\" -framework Foundation -framework Cocoa -framework CoreData -fmodules #{extra_gcc_args}"
+  run_or_die "clang -o testbin test.m MyBaseClass.m Gender.m MOs/*.m -I\"#{Dir.pwd}\" -framework Foundation -framework Cocoa -framework CoreData -fmodules #{extra_llvm_args}"
   run_or_die "xcrun momc -MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS test.xcdatamodel \"#{Dir.pwd}/test.mom\""
   puts run_or_die './testbin'
 end
 
-desc 'Generate, Compile and Run MRC Code (with objc literals)'
-task :mrc do
-  gen_and_compile('MRC (with objc literals)', mogenPath, '', '')
-end
-
-desc 'Generate, Compile and Run MRC Code (without objc literals)'
-task :mrc_noliterals do
-  gen_and_compile('MRC (without objc literals)', mogenPath, '--template-var noliterals=true', '')
-end
-
-desc 'Generate, Compile and Run ARC Code (with objc literals)'
-task :arc do
-  gen_and_compile('ARC (with objc literals)', mogenPath, '--template-var arc=true', '-fobjc-arc')
-end
-
-desc 'Generate, Compile and Run ARC Code (without objc literals)'
-task :arc_noliterals do
-  gen_and_compile('ARC (without objc literals)', mogenPath, '--template-var arc=true --template-var noliterals=true', '-fobjc-arc')
-end
-
-desc 'Generate, Compile and Run ARC Code (without objc literals)'
-task :v2 do
+desc 'Generate, Compile and Run Objective-C'
+task :objc do
   Rake::Task[:clean].execute
-  gen_and_compile('v2 (ARC + objc literals)', mogenPath, '--v2', '-fobjc-arc')
+  gen_and_compile('Modern Objective-C', mogenPath, '', '-fobjc-arc')
   Rake::Task[:clean].execute
 end
 
@@ -56,16 +36,7 @@ end
 
 task :default do
   Rake::Task[:clean].execute
-  
-  Rake::Task[:mrc].execute
-  Rake::Task[:clean].execute
-  
-  Rake::Task[:mrc_noliterals].execute
-  Rake::Task[:clean].execute
-  
-  Rake::Task[:arc].execute
-  Rake::Task[:clean].execute
-  
-  Rake::Task[:arc_noliterals].execute
-  Rake::Task[:clean].execute
+
+  Rake::Task[:objc].execute
+#  Rake::Task[:clean].execute
 end


### PR DESCRIPTION
As part of modernizing mogenerator for a 2.0 (or whatever we call it), I’ve removed the —v2 argument and now we generate Objective-C using ARC, Objective-C literals, and modules out of the box.

There’s still some stuff I don’t like about our Objective-C code I’d like to fix. Namely, the structs for attribute names need to be marked `__unsafe_unretained` because ARC doesn’t support objects in a struct. I wasn’t sure of a better way to handle that without adding a bunch of extra code. 

I’d also like to add nullability attributes to Objective-C where appropriate, but we can save that for another day (Patches Welcomed!)

This is obviously a breaking change, and I always opt to go fairly heavy handed on that in favor of moving the project forward. Feedback welcomed.