### PR TITLE
Add generics support in Objective-C templates

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -103,11 +103,23 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$endif$>
 <$if Relationship.isToMany$>
 <$if TemplateVar.arc$>
+<$if TemplateVar.generics$>
+@property (nonatomic, strong) <$Relationship.immutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *<$Relationship.name$>;
+<$else$>
 @property (nonatomic, strong) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
+<$endif$>
+<$else$>
+<$if TemplateVar.generics$>
+@property (nonatomic, retain) <$Relationship.immutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *<$Relationship.name$>;
 <$else$>
 @property (nonatomic, retain) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
 <$endif$>
+<$endif$>
+<$if TemplateVar.generics$>
+- (<$Relationship.mutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *)<$Relationship.name$>Set;
+<$else$>
 - (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
+<$endif$>
 <$else$>
 <$if TemplateVar.arc$>
 @property (nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
@@ -150,8 +162,13 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
 @interface _<$managedObjectClassName$> (<$Relationship.name.initialCapitalString$>CoreDataGeneratedAccessors)
+<$if TemplateVar.generics$>
+- (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *)value_;
+- (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *)value_;
+<$else$>
 - (void)add<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>:(<$Relationship.immutableCollectionClassName$>*)value_;
+<$endif$>
 - (void)add<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
 - (void)remove<$Relationship.name.initialCapitalString$>Object:(<$Relationship.destinationEntity.managedObjectClassName$>*)value_;
 <$if Relationship.isOrdered$>
@@ -179,8 +196,13 @@ extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userI
 <$endforeach do$>
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
+<$if TemplateVar.generics$>
+- (<$Relationship.mutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *)primitive<$Relationship.name.initialCapitalString$>;
+- (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.mutableCollectionClassName$><<$Relationship.destinationEntity.managedObjectClassName$> *> *)value;
+<$else$>
 - (<$Relationship.mutableCollectionClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
 - (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.mutableCollectionClassName$>*)value;
+<$endif$>
 <$else$>
 - (<$Relationship.destinationEntity.managedObjectClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
 - (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.destinationEntity.managedObjectClassName$>*)value;


### PR DESCRIPTION
Adds template var `generics`. --v2 does not enable it by default. Explicit `--template-var generics=true` is necessary for it to work.

Tested on my own app, works as expected.
Fixes #306. 
