### PR TITLE
optional should be set to no unless it appears in XML attributes

### DIFF
--- a/momcom/NSPropertyDescription+momcom.m
+++ b/momcom/NSPropertyDescription+momcom.m
@@ -19,6 +19,9 @@
     }
 
     NSPropertyDescription *propertyDescription = [[self alloc] init];
+    // set optional to `NO`, unless it appears in XML attributes
+    propertyDescription.optional = NO;
+    
     BOOL syncable = NO;
 
     for (NSXMLNode *xmlAttribute in [xmlNode attributes]) {


### PR DESCRIPTION
A fresh NSPropertyDescription has optional set to yes by default. Therefore it needs to be set to no unless it appears in the XML attributes.