### PR TITLE
Fix tmpdir permission on el capitan

### DIFF
--- a/build-mogenerator-Info-plist.sh
+++ b/build-mogenerator-Info-plist.sh
@@ -1,4 +1,4 @@
-rm -f $TMPDIR/mogenerator-Info.plist
+rm -f $PROJECT_TEMP_DIR/mogenerator-Info.plist
 /usr/libexec/PlistBuddy \
 	-c "Clear" \
 	-c "Import :human.h.motemplate templates/human.h.motemplate" \
@@ -7,4 +7,4 @@ rm -f $TMPDIR/mogenerator-Info.plist
 	-c "Import :machine.h.motemplate templates/machine.h.motemplate" \
 	-c "Import :machine.m.motemplate templates/machine.m.motemplate" \
 	-c "Import :machine.swift.motemplate templates/machine.swift.motemplate" \
-	$TMPDIR/mogenerator-Info.plist
+	$PROJECT_TEMP_DIR/mogenerator-Info.plist

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"$TMPDIR/mogenerator-Info.plist",
+					"$PROJECT_TEMP_DIR/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";
@@ -552,7 +552,7 @@
 					"-sectcreate",
 					__TEXT,
 					__info_plist,
-					"$TMPDIR/mogenerator-Info.plist",
+					"$PROJECT_TEMP_DIR/mogenerator-Info.plist",
 				);
 				PRODUCT_NAME = mogenerator;
 				WARNING_CFLAGS = "-Wall";


### PR DESCRIPTION
This commit fixes compiling error mentioned in issue #314 
On El Capitan, compiler seems not permitted to read from `$TMPDIR`, so changing it to `$PROJECT_TEMP_DIR` works.