### PR TITLE
Nullability & New Attribute Objects for Objective-C Templates

### DIFF
--- a/templates/human.h.motemplate
+++ b/templates/human.h.motemplate
@@ -1,5 +1,5 @@
 #import "_<$managedObjectClassName$>.h"
 
-@interface <$managedObjectClassName$> : _<$managedObjectClassName$> {}
+@interface <$managedObjectClassName$> : _<$managedObjectClassName$>
 // Custom logic goes here.
 @end

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -10,6 +10,7 @@
 #import "<$additionalHeaderFileName$>"
 <$endif$>
 
+NS_ASSUME_NONNULL_BEGIN
 <$if noninheritedAttributes.@count > 0$>
 @interface <$managedObjectClassName$>Attributes: NSObject <$foreach Attribute noninheritedAttributes do$>
 + (NSString *)<$Attribute.name$>;<$endforeach do$>
@@ -53,11 +54,12 @@
  * <$userInfo.discussion$>
  */
 <$endif$>
+
 @interface _<$managedObjectClassName$> : <$customSuperentity$>
 + (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-@property (nonatomic, readonly, strong) <$managedObjectClassName$>ID* objectID;
+@property (nonatomic, readonly, strong) <$managedObjectClassName$>ID*objectID;
 
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.userInfo.documentation$>
@@ -69,9 +71,9 @@
 <$endif$>
 <$if Attribute.hasDefinedAttributeType$>
 <$if Attribute.isReadonly$>
-@property (nonatomic, strong, readonly) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+@property (nonatomic, strong, readonly<$if Attribute.optional$>, nullable<$endif$>) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$else$>
-@property (nonatomic, strong) <$Attribute.objectAttributeType$> <$Attribute.name$>;
+@property (nonatomic, strong<$if Attribute.optional$>, nullable<$endif$>) <$Attribute.objectAttributeType$> <$Attribute.name$>;
 <$endif$>
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
@@ -95,10 +97,10 @@
  */
 <$endif$>
 <$if Relationship.isToMany$>
-@property (nonatomic, strong) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
-- (<$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
+@property (nonatomic, strong<$if Relationship.optional$>, nullable<$endif$>) <$Relationship.immutableCollectionClassName$> *<$Relationship.name$>;
+- (<$if Relationship.optional$>nullable <$endif$><$Relationship.mutableCollectionClassName$>*)<$Relationship.name$>Set;
 <$else$>
-@property (nonatomic, strong) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
+@property (nonatomic, strong<$if Relationship.optional$>, nullable<$endif$>) <$Relationship.destinationEntity.managedObjectClassName$> *<$Relationship.name$>;
 //- (BOOL)validate<$Relationship.name.initialCapitalString$>:(id*)value_ error:(NSError**)error_;
 <$endif$>
 <$endforeach do$>
@@ -119,7 +121,7 @@
  * <$FetchedProperty.userInfo.discussion$>
  */
 <$endif$>
-@property (nonatomic, readonly) NSArray *<$FetchedProperty.name$>;
+@property (nonatomic, readonly<$if FetchedProperty.optional$>, nullable<$endif$>) NSArray *<$FetchedProperty.name$>;
 <$endforeach do$>
 <$if TemplateVar.frc$>
 #if TARGET_OS_IPHONE
@@ -131,6 +133,7 @@
 #endif
 <$endif$>
 @end
+
 
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
@@ -172,3 +175,4 @@
 <$endif$>
 <$endforeach do$>
 @end
+NS_ASSUME_NONNULL_END

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -11,27 +11,27 @@
 <$endif$>
 
 <$if noninheritedAttributes.@count > 0$>
-extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>
-	__unsafe_unretained NSString *<$Attribute.name$>;<$endforeach do$>
-} <$managedObjectClassName$>Attributes;
+@interface <$managedObjectClassName$>Attributes: NSObject <$foreach Attribute noninheritedAttributes do$>
++ (NSString *)<$Attribute.name$>;<$endforeach do$>
+@end
 <$endif$>
 
 <$if noninheritedRelationships.@count > 0$>
-extern const struct <$managedObjectClassName$>Relationships {<$foreach Relationship noninheritedRelationships do$>
-	__unsafe_unretained NSString *<$Relationship.name$>;<$endforeach do$>
-} <$managedObjectClassName$>Relationships;
+@interface <$managedObjectClassName$>Relationships: NSObject<$foreach Relationship noninheritedRelationships do$>
++ (NSString *)<$Relationship.name$>;<$endforeach do$>
+@end
 <$endif$>
 
 <$if noninheritedFetchedProperties.@count > 0$>
-extern const struct <$managedObjectClassName$>FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
-	__unsafe_unretained NSString *<$FetchedProperty.name$>;<$endforeach do$>
-} <$managedObjectClassName$>FetchedProperties;
+@interface <$managedObjectClassName$>FetchedProperties: NSObject<$foreach FetchedProperty noninheritedFetchedProperties do$>
++ (NSString *)<$FetchedProperty.name$>;<$endforeach do$>
+@end
 <$endif$>
 
 <$if hasUserInfoKeys$>
-extern const struct <$managedObjectClassName$>UserInfo {<$foreach UserInfo userInfoKeyValues do$>
-	__unsafe_unretained NSString *<$UserInfo.key$>;<$endforeach do$>
-} <$managedObjectClassName$>UserInfo;
+@interface <$managedObjectClassName$>UserInfo: NSObject <$foreach UserInfo userInfoKeyValues do$>
++ (NSString *)<$UserInfo.key$>;<$endforeach do$>
+@end
 <$endif$>
 
 <$foreach Relationship noninheritedRelationships do$>@class <$Relationship.destinationEntity.managedObjectClassName$>;

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -53,8 +53,8 @@
  * <$userInfo.discussion$>
  */
 <$endif$>
-@interface _<$managedObjectClassName$> : <$customSuperentity$> {}
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
+@interface _<$managedObjectClassName$> : <$customSuperentity$>
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
 @property (nonatomic, readonly, strong) <$managedObjectClassName$>ID* objectID;
@@ -104,8 +104,8 @@
 <$endforeach do$>
 <$foreach FetchRequest prettyFetchRequests do$>
 <$if FetchRequest.singleResult$>
-+ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
-+ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
++ (instancetype)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
++ (instancetype)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;
 <$else$>
 + (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>;
 + (NSArray*)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_;

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -4,27 +4,35 @@
 #import "_<$managedObjectClassName$>.h"
 
 <$if noninheritedAttributes.@count > 0$>
-const struct <$managedObjectClassName$>Attributes <$managedObjectClassName$>Attributes = {<$foreach Attribute noninheritedAttributes do$>
-	.<$Attribute.name$> = @"<$Attribute.name$>",<$endforeach do$>
-};
+@implementation <$managedObjectClassName$>Attributes <$foreach Attribute noninheritedAttributes do$>
++ (NSString *)<$Attribute.name$> {
+	return @"<$Attribute.name$>";
+}<$endforeach do$>
+@end
 <$endif$>
 
 <$if noninheritedRelationships.@count > 0$>
-const struct <$managedObjectClassName$>Relationships <$managedObjectClassName$>Relationships = {<$foreach Relationship noninheritedRelationships do$>
-	.<$Relationship.name$> = @"<$Relationship.name$>",<$endforeach do$>
-};
+@implementation <$managedObjectClassName$>Relationships <$foreach Relationship noninheritedRelationships do$>
++ (NSString *)<$Relationship.name$> {
+	return @"<$Relationship.name$>";
+}<$endforeach do$>
+@end
 <$endif$>
 
 <$if noninheritedFetchedProperties.@count > 0$>
-const struct <$managedObjectClassName$>FetchedProperties <$managedObjectClassName$>FetchedProperties = {<$foreach FetchedProperty noninheritedFetchedProperties do$>
-	.<$FetchedProperty.name$> = @"<$FetchedProperty.name$>",<$endforeach do$>
-};
+@implementation <$managedObjectClassName$>FetchedProperties <$foreach FetchedProperty noninheritedFetchedProperties do$>
++ (NSString *)<$FetchedProperty.name$> {
+	return @"<$FetchedProperty.name$>";
+}<$endforeach do$>
+@end
 <$endif$>
 
 <$if hasUserInfoKeys$>
-const struct <$managedObjectClassName$>UserInfo <$managedObjectClassName$>UserInfo = {<$foreach UserInfo userInfoKeyValues do$>
-	.<$UserInfo.key$> = @"<$UserInfo.value$>",<$endforeach do$>
-};
+@implementation <$managedObjectClassName$>UserInfo <$foreach UserInfo userInfoKeyValues do$>
++ (NSString *)<$UserInfo.key$> {
+	return @"<$UserInfo.value$>";
+}<$endforeach do$>
+@end
 <$endif$>
 
 @implementation <$managedObjectClassName$>ID

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -40,7 +40,7 @@
 
 @implementation _<$managedObjectClassName$>
 
-+ (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_ {
++ (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_ {
 	NSParameterAssert(moc_);
 	return [NSEntityDescription insertNewObjectForEntityForName:@"<$name$>" inManagedObjectContext:moc_];
 }
@@ -125,7 +125,7 @@
 
 <$foreach FetchRequest prettyFetchRequests do$>
 <$if FetchRequest.singleResult$>
-+ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
++ (instancetype)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>{
 	NSError *error = nil;
 	id result = [self fetch<$FetchRequest.name.initialCapitalString$>:moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:<$Binding.name$>_ <$endforeach do2$>error:&error];
 	if (error) {
@@ -137,7 +137,7 @@
 	}
 	return result;
 }
-+ (id)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
++ (instancetype)fetch<$FetchRequest.name.initialCapitalString$>:(NSManagedObjectContext*)moc_ <$foreach Binding FetchRequest.bindings do2$><$Binding.name$>:(<$Binding.type$>)<$Binding.name$>_ <$endforeach do2$>error:(NSError**)error_ {
 	NSParameterAssert(moc_);
 	NSError *error = nil;
 


### PR DESCRIPTION
I'm working on getting our ObjC templates updates. 

Here's what's new in this one:

1. I replaced the old `struct` objects we were using for relationship and attribute names with first class `NSObject` instances. This lets us not annoy the Apple gods by putting NS objects inside structs, which is a no-no in ARC land. (`__unsafe_unretained` is cheating)
2. Added nullability attributes where appropriate for attributes, relationships, and fetched properties. 

I still want to add lightweight generic support, but that is going to require some internal surgery I think.