### PR TITLE
Make entityInManagedObjectContext: nullable

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface _<$managedObjectClassName$> : <$customSuperentity$>
 + (instancetype)insertInManagedObjectContext:(NSManagedObjectContext *)moc_;
 + (NSString*)entityName;
-+ (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
++ (nullable NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
 @property (nonatomic, readonly, strong) <$managedObjectClassName$>ID *objectID;
 
 <$foreach Attribute noninheritedAttributes do$>


### PR DESCRIPTION
### Summary of Changes

One line change to offer appropriate nullability in machine consumption headers.

### Addresses

Partially addresses https://github.com/rentzsch/mogenerator/issues/336

Because NSEntityDescription#entityForName:inManagedObjectContext: is
nullable