### PR TITLE
Updates "Core Data Programming Guide" Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         	    <dt>mogenerator</dt>
         		<dd>
         		    <p>generates Objective-C code for your
-        		        <a href="http://developer.apple.com/mac/library/documentation/Cocoa/Conceptual/CoreData/cdProgrammingGuide.html">Core Data</a> custom classes</p>
+        		        <a href="https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/CoreData/index.html#//apple_ref/doc/uid/TP40001075">Core Data</a> custom classes</p>
                     <p>Unlike Xcode, mogenerator manages <em>two</em> classes per entity:
                         one for <strong>machines</strong>, one for <strong>humans</strong></p>
                     <p>The machine class can always be overwritten to match the data model,


### PR DESCRIPTION
### Summary of Changes

Updates the link to Apple's "Core Data Programming Guide".

**Note** The original link pointed to the Mac documentation, but it looks like the iOS and Mac URLs now link to the same content.

### Addresses

None

Apple loves to move pages around...