### PR TITLE
Add nullability to the primitive value

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -146,8 +146,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface _<$managedObjectClassName$> (CoreDataGeneratedPrimitiveAccessors)
 <$foreach Attribute noninheritedAttributesSansType do$>
 <$if Attribute.hasDefinedAttributeType$>
-- (<$Attribute.objectAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
-- (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$Attribute.objectAttributeType$>)value;
+- (<$if Attribute.optional$>nullable <$endif$><$Attribute.objectAttributeType$>)primitive<$Attribute.name.initialCapitalString$>;
+- (void)setPrimitive<$Attribute.name.initialCapitalString$>:(<$if Attribute.optional$>nullable <$endif$><$Attribute.objectAttributeType$>)value;
 <$if Attribute.hasScalarAttributeType$>
 - (<$Attribute.scalarAttributeType$>)primitive<$Attribute.name.initialCapitalString$>Value;
 - (void)setPrimitive<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;


### PR DESCRIPTION
### Summary of Changes

Modified the machine template header to consider nullability for the getter and setter of a primitive defined attribute type.

A defined attribute can be nullable, so the getter and setter of the primitive should consider nullable.