### PR TITLE
Support for “Uses Scalar Type”.

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -31,6 +31,7 @@
 
 @interface NSAttributeDescription (typing)
 - (BOOL)hasScalarAttributeType;
+- (BOOL)usesScalarAttributeType;
 - (NSString*)scalarAttributeType;
 - (NSString*)scalarAccessorMethodName;
 - (NSString*)scalarFactoryMethodName;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -5,6 +5,7 @@
 
 #import "mogenerator.h"
 #import "NSManagedObjectModel+momcom.h"
+#import "NSAttributeDescription+momcom.h"
 #import "NSString+MORegEx.h"
 
 static NSString * const kTemplateVar = @"TemplateVar";
@@ -15,6 +16,8 @@ static BOOL       gSwift;
 
 static const NSString *const kAttributeValueScalarTypeKey = @"attributeValueScalarType";
 static const NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFileName";
+static const NSString *const kCustomBaseClass = @"mogenerator.customBaseClass";
+static const NSString *const kReadOnly = @"mogenerator.readonly";
 
 @interface NSEntityDescription (fetchedPropertiesAdditions)
 - (NSDictionary*)fetchedPropertiesByName;
@@ -194,7 +197,7 @@ static const NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFi
     }
 }
 - (NSString*)forcedCustomBaseClass {
-    NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:@"mogenerator.customBaseClass"];
+    NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:kCustomBaseClass];
     return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
 }
 /** @TypeInfo NSAttributeDescription */
@@ -419,8 +422,18 @@ static const NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFi
             return NO;
     }
 }
-- (NSString*)scalarAttributeType {
 
+- (BOOL)usesScalarAttributeType {
+    NSNumber *usesScalarAttributeType = [[self userInfo] objectForKey:kUsesScalarAttributeType];
+
+    if (usesScalarAttributeType) {
+        return usesScalarAttributeType.boolValue;
+    } else {
+        return NO;
+    }
+}
+
+- (NSString*)scalarAttributeType {
     BOOL isUnsigned = [self isUnsigned];
 
     NSString *attributeValueScalarType = [[self userInfo] objectForKey:kAttributeValueScalarTypeKey];
@@ -576,7 +589,7 @@ static const NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFi
 }
 
 - (BOOL)isReadonly {
-    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:@"mogenerator.readonly"];
+    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:kReadOnly];
     if (readonlyUserinfoValue != nil) {
         return YES;
     }

--- a/momcom/NSAttributeDescription+momcom.h
+++ b/momcom/NSAttributeDescription+momcom.h
@@ -8,6 +8,8 @@
 
 @import CoreData;
 
+extern const NSString *const kUsesScalarAttributeType;
+
 @interface NSAttributeDescription (momcom)
 
 + (NSAttributeDescription *)baseEntityForXML:(NSXMLElement *)xmlNode;

--- a/momcom/NSAttributeDescription+momcom.m
+++ b/momcom/NSAttributeDescription+momcom.m
@@ -10,6 +10,7 @@
 #import "NSPropertyDescription+momcom.h"
 
 static NSDictionary *attributeTypeForString;
+const NSString *const kUsesScalarAttributeType = @"mogenerator.usesScalarAttributeType";
 
 @implementation NSAttributeDescription (momcom)
 
@@ -44,7 +45,14 @@ static NSDictionary *attributeTypeForString;
             [attributeDescription setAttributeType:[attributeType integerValue]];
         }
     }
-    
+
+    NSXMLNode *userScalarElement = [xmlNode attributeForName:@"usesScalarValueType"];
+    if (userScalarElement != nil) {
+        NSMutableDictionary *userInfo = [[attributeDescription userInfo] mutableCopy];
+        userInfo[kUsesScalarAttributeType] = [userScalarElement stringValue];
+        [attributeDescription setUserInfo:userInfo.copy];
+    }
+
     NSXMLNode *defaultValueElement = [xmlNode attributeForName:@"defaultValueString"];
     if (defaultValueElement != nil) {
         NSString *defaultValueString = [defaultValueElement stringValue];

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -23,10 +23,10 @@ public enum <$sanitizedManagedObjectClassName$>FetchedProperties: String {<$fore
 }
 <$endif$>
 
-<$if hasUserInfoKeys && userInfoKeyValues.@count > 0$>		
-public enum <$sanitizedManagedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>		
-    case <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>		
-}		
+<$if hasUserInfoKeys && userInfoKeyValues.@count > 0$>
+public enum <$sanitizedManagedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
+    case <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
+}
 <$endif$>
 
 
@@ -61,29 +61,29 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
 <$if Attribute.hasDefinedAttributeType$>
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
-    open var <$Attribute.name$>: NSNumber?
+    open var <$Attribute.name$>: <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$if Attribute.isOptional$> // Optional scalars not supported<$endif$><$else$>NSNumber<$if Attribute.isOptional$>?<$else$>!<$endif$><$endif$>
     {
         self.willAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        let <$Attribute.name$> = self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? NSNumber
+        let <$Attribute.name$> = self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$else$>NSNumber<$endif$>
         self.didAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
         return <$Attribute.name$>
     }
 <$else$>
     @NSManaged open
-    var <$Attribute.name$>: NSNumber?
+    var <$Attribute.name$>: <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$if Attribute.isOptional$> // Optional scalars not supported<$endif$><$else$>NSNumber<$if Attribute.isOptional$>?<$else$>!<$endif$><$endif$>
 <$endif$>
 <$else$>
 <$if Attribute.isReadonly$>
-    open var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
+    open var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$else$>!<$endif$>
     {
         self.willAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        let <$Attribute.name$> =self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? <$Attribute.objectAttributeType$>
+        let <$Attribute.name$> = self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? <$Attribute.objectAttributeType$>
         self.didAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
         return <$Attribute.name$>
     }
 <$else$>
     @NSManaged open
-    var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
+    var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$else$>!<$endif$>
 <$endif$>
 <$endif$>
 <$endif$>


### PR DESCRIPTION
### Summary of Changes

The `Uses Scalar Type` checkbox was not handled and therefore when using a swift template the generated output was wrong. Instead of using scalars it was always generated as `NSNumber`.

Now it mimics the behaviour of the Xcode generator.

Because the `usesScalarValueType` is not (yet) available on `NSAttributeDescription` I used a `userInfo` entry to pass the value around.