### PR TITLE
Expose allAttributes and allRelationships, related to #328

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -201,6 +201,11 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
     return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
 }
 /** @TypeInfo NSAttributeDescription */
+- (NSArray*)allAttributes {
+    NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
+    return [[[self attributesByName] allValues] sortedArrayUsingDescriptors:sortDescriptors];
+}
+/** @TypeInfo NSAttributeDescription */
 - (NSArray*)noninheritedAttributes {
     NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
     NSEntityDescription *superentity = [self superentity];
@@ -233,7 +238,12 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
     }
     return filteredAttributeDescriptions;
 }
-/** @TypeInfo NSAttributeDescription */
+/** @TypeInfo NSRelationshipDescription */
+- (NSArray*)allRelationships {
+    NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
+    return [[[self relationshipsByName] allValues] sortedArrayUsingDescriptors:sortDescriptors];
+}
+/** @TypeInfo NSRelationshipDescription */
 - (NSArray*)noninheritedRelationships {
     NSArray *sortDescriptors = [NSArray arrayWithObject:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
     NSEntityDescription *superentity = [self superentity];


### PR DESCRIPTION
### Summary of Changes

Expose an allAttributes and allRelationships accessors so that code can be generated to also reference descriptions excluded by noninheritedAttributes and noninheritedRelationships.

### Addresses

Addresses [EntityAttributes should also be present in ChildEntity-Attributes](https://github.com/rentzsch/mogenerator/issues/328)
