### PR TITLE
Nullability annotations for generated primitive accessors

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -159,8 +159,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (<$Relationship.mutableCollectionClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
 - (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.mutableCollectionClassName$>*)value;
 <$else$>
-- (<$Relationship.destinationEntity.managedObjectClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
-- (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$Relationship.destinationEntity.managedObjectClassName$>*)value;
+- (<$if Relationship.optional$>nullable <$endif$><$Relationship.destinationEntity.managedObjectClassName$>*)primitive<$Relationship.name.initialCapitalString$>;
+- (void)setPrimitive<$Relationship.name.initialCapitalString$>:(<$if Relationship.optional$>nullable <$endif$><$Relationship.destinationEntity.managedObjectClassName$>*)value;
 <$endif$>
 <$endforeach do$>
 @end


### PR DESCRIPTION
### Summary of Changes

Add nullability annotations for generated primitive accessors of optional, to-one relationships.

### Addresses

https://github.com/rentzsch/mogenerator/issues/361