### PR TITLE
Swift-ifed templates

### DIFF
--- a/templates/human.swift.motemplate
+++ b/templates/human.swift.motemplate
@@ -1,6 +1,15 @@
 import Foundation
+import CoreData
 
-@objc(<$managedObjectClassName$>)
-open class <$managedObjectClassName$>: _<$managedObjectClassName$> {
-	// Custom logic goes here.
+@objc(<$sanitizedManagedObjectClassName$>)
+open class <$sanitizedManagedObjectClassName$>: <$customSuperentity$> {
+
+    public override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+
+	required public init?(managedObjectContext moc: NSManagedObjectContext) {
+		guard let entity = NSEntityDescription.entity(forEntityName: "<$managedObjectClassName$>", in: moc) else { return nil }
+		super.init(entity: entity, insertInto: moc)
+	}
 }

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -1,99 +1,81 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
-// Make changes to <$sanitizedManagedObjectClassName$>.swift instead.
+// Make changes to <$managedObjectClassName$>.swift instead.
 
-import Foundation
 import CoreData
+<$if hasAdditionalHeaderFile$>import <$additionalHeaderFileName$><$endif$>
 <$if hasCustomBaseCaseImport$>import <$baseClassImport$><$endif$>
 
-<$if noninheritedAttributes.@count > 0$>
-public enum <$sanitizedManagedObjectClassName$>Attributes: String {<$foreach Attribute noninheritedAttributes do$>
-    case <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>
-}
-<$endif$>
 
-<$if noninheritedRelationships.@count > 0$>
-public enum <$sanitizedManagedObjectClassName$>Relationships: String {<$foreach Relationship noninheritedRelationships do$>
-    case <$Relationship.name$> = "<$Relationship.name$>"<$endforeach do$>
-}
-<$endif$>
-
-<$if noninheritedFetchedProperties.@count > 0$>
-public enum <$sanitizedManagedObjectClassName$>FetchedProperties: String {<$foreach FetchedProperty noninheritedFetchedProperties do$>
-    case <$FetchedProperty.name$> = "<$FetchedProperty.name$>"<$endforeach do$>
-}
-<$endif$>
-
-<$if hasUserInfoKeys && userInfoKeyValues.@count > 0$>
-public enum <$sanitizedManagedObjectClassName$>UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
-    case <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
-}
-<$endif$>
-
-
-<$if hasCustomSuperentity $>
-open class _<$sanitizedManagedObjectClassName$>: <$customSuperentity$> {
-<$else$>
-open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
-<$endif$>
-    // MARK: - Class methods
-
-    <$if (hasCustomSuperclass || (hasCustomSuperentity && TemplateVar.overrideBaseClass))$>override <$endif$>open class func entityName () -> String {
+public extension <$managedObjectClassName$> {
+	
+    <$if (hasCustomSuperclass || (hasCustomSuperentity && TemplateVar.overrideBaseClass))$>override <$endif$>open class var entityName: String {
         return "<$name$>"
     }
 
     <$if (hasCustomSuperclass || (hasCustomSuperentity && TemplateVar.overrideBaseClass))$>override <$endif$>open class func entity(managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-        return NSEntityDescription.entity(forEntityName: self.entityName(), in: managedObjectContext)
+        return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
     }
+	
+	<$if noninheritedAttributes.@count > 0$>
+	public struct Attributes {<$foreach Attribute noninheritedAttributes do$>
+		static let <$Attribute.name$> = "<$Attribute.name$>"<$endforeach do$>
+	}
+	<$endif$>
 
-    @nonobjc
-    open class func fetchRequest() -> NSFetchRequest<<$sanitizedManagedObjectClassName$>> {
-        if #available(iOS 10.0, tvOS 10.0, watchOS 3.0, macOS 10.12, *) {
-            return NSManagedObject.fetchRequest() as! NSFetchRequest<<$sanitizedManagedObjectClassName$>>
-        } else {
-            return NSFetchRequest(entityName: self.entityName())
-        }
-    }
+	<$if noninheritedRelationships.@count > 0$>
+	public struct Relationships {<$foreach Relationship noninheritedRelationships do$>
+		static let <$Relationship.name$> = "<$Relationship.name$>"<$endforeach do$>
+	}
+	<$endif$>
 
-    // MARK: - Life cycle methods
+	<$if noninheritedFetchedProperties.@count > 0$>
+	public struct FetchedProperties {<$foreach FetchedProperty noninheritedFetchedProperties do$>
+	    static let <$FetchedProperty.name$> = "<$FetchedProperty.name$>"<$endforeach do$>
+	}
+	<$endif$>
 
-    public override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
-        super.init(entity: entity, insertInto: context)
-    }
-
-    public convenience init?(managedObjectContext: NSManagedObjectContext) {
-        guard let entity = _<$sanitizedManagedObjectClassName$>.entity(managedObjectContext: managedObjectContext) else { return nil }
-        self.init(entity: entity, insertInto: managedObjectContext)
-    }
-
+	<$if hasUserInfoKeys && userInfoKeyValues.@count > 0$>
+	public struct UserInfo: String {<$foreach UserInfo userInfoKeyValues do$>
+	    static let <$UserInfo.key$> = "<$UserInfo.key$>"<$endforeach do$>
+	}
+	<$endif$>
+	
     // MARK: - Properties
 <$foreach Attribute noninheritedAttributes do$>
-<$if Attribute.hasDefinedAttributeType$>
+<$if Attribute.hasDefinedAttributeType$>	
 <$if Attribute.hasScalarAttributeType$>
-<$if Attribute.isReadonly$>
-    open var <$Attribute.name$>: <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$if Attribute.isOptional$> // Optional scalars not supported<$endif$><$else$>NSNumber<$if Attribute.isOptional$>?<$else$>!<$endif$><$endif$>
-    {
-        self.willAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        let <$Attribute.name$> = self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$else$>NSNumber<$endif$>
-        self.didAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        return <$Attribute.name$>
-    }
+
+<$if Attribute.isOptional$>
+<$if Attribute.usesScalarAttributeType$>
+	public<$if Attribute.isReadonly$>private(set)<$endif$> var <$Attribute.name$>: <$Attribute.scalarAttributeType$>? {
+		get {
+			let key = <$managedObjectClassName$>.Attributes.<$Attribute.name$>
+			willAccessValue(forKey: key)
+			defer { didAccessValue(forKey: key) }
+
+			return primitiveValue(forKey: key) as? <$Attribute.scalarAttributeType$>
+		}
+		set {
+			let key = <$managedObjectClassName$>.Attributes.<$Attribute.name$>
+			willChangeValue(forKey: key)
+			defer { didChangeValue(forKey: key) }
+
+			guard let value = newValue else {
+				setPrimitiveValue(nil, forKey: key)
+				return
+			}
+			setPrimitiveValue(value, forKey: key)
+		}
+	}
 <$else$>
-    @NSManaged open
-    var <$Attribute.name$>: <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$if Attribute.isOptional$> // Optional scalars not supported<$endif$><$else$>NSNumber<$if Attribute.isOptional$>?<$else$>!<$endif$><$endif$>
+	@NSManaged public<$if Attribute.isReadonly$>private(set)<$endif$> var <$Attribute.name$>: NSNumber?
 <$endif$>
 <$else$>
-<$if Attribute.isReadonly$>
-    open var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$else$>!<$endif$>
-    {
-        self.willAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        let <$Attribute.name$> = self.primitiveValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue) as? <$Attribute.objectAttributeType$>
-        self.didAccessValue(forKey: <$sanitizedManagedObjectClassName$>Attributes.<$Attribute.name$>.rawValue)
-        return <$Attribute.name$>
-    }
-<$else$>
-    @NSManaged open
-    var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$else$>!<$endif$>
+	@NSManaged public<$if Attribute.isReadonly$>private(set)<$endif$> var <$Attribute.name$>: <$if Attribute.usesScalarAttributeType$><$Attribute.scalarAttributeType$><$else$>NSNumber<$endif$>
 <$endif$>
+
+<$else$>
+    @NSManaged public<$if Attribute.isReadonly$>private(set)<$endif$> var <$Attribute.name$>: <$Attribute.objectAttributeType$><$if Attribute.isOptional$>?<$endif$>
 <$endif$>
 <$endif$>
 <$endforeach do$>
@@ -101,115 +83,14 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
     // MARK: - Relationships
 <$foreach Relationship noninheritedRelationships do$>
 <$if Relationship.isToMany$>
-    @NSManaged open
-    var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
-
-    open func <$Relationship.name$>Set() -> <$Relationship.mutableCollectionClassName$> {
-        return self.<$Relationship.name$>.mutableCopy() as! <$Relationship.mutableCollectionClassName$>
-    }
-
+    @NSManaged public var <$Relationship.name$>: Set<<$Relationship.destinationEntity.managedObjectClassName$>><$if Relationship.isOptional$>?<$endif$>
 <$else$>
-    @NSManaged open
-    var <$Relationship.name$>: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$><$if Relationship.isOptional$>?<$endif$>
-<$endif$>
-<$endforeach do$>
-
-<$foreach FetchRequest prettyFetchRequests do$>
-<$if FetchRequest.singleResult$>
-    class func fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: NSManagedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.type$><$endforeach do2$>) -> Any? {
-        return self.fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: managedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.name$><$endforeach do2$>, error: nil)
-    }
-
-    class func fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: NSManagedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.type$><$endforeach do2$>, error outError: NSErrorPointer) -> Any? {
-        guard let psc = managedObjectContext.persistentStoreCoordinator else { return nil }
-        let model = psc.managedObjectModel
-		let substitutionVariables : [String : Any] = [<$if FetchRequest.hasBindings$><$foreach Binding FetchRequest.bindings do2$>
-		            "<$Binding.name$>": <$Binding.name$>,
-		<$endforeach do2$><$else$>:<$endif$>]
-
-        guard let fetchRequest = model.fetchRequestFromTemplate(withName: "<$FetchRequest.name$>", substitutionVariables: substitutionVariables) else {
-          assert(false, "Can't find fetch request named \"<$FetchRequest.name$>\".")
-          return nil
-        }
-
-        var result: Any? = nil
-        do {
-            let results = try managedObjectContext.fetch(fetchRequest)
-            switch results.count {
-            case 0:
-                // Nothing found matching the fetch request. That's cool, though: we'll just return nil.
-                break
-            case 1:
-                result = results.first
-            default:
-                print("WARN fetch request <$FetchRequest.name$>: 0 or 1 objects expected, \(results.count) found (substitutionVariables: \(substitutionVariables), results: \(results))")
-            }
-
-        } catch {
-            print("Error executing fetch request: \(error)")
-        }
-        return result
-    }
-<$else$>
-    class func fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: NSManagedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.type$><$endforeach do2$>) -> [Any]? {
-        return self.fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: managedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.name$><$endforeach do2$>, error: nil)
-    }
-
-    class func fetch<$FetchRequest.name.initialCapitalString$>(managedObjectContext: NSManagedObjectContext<$foreach Binding FetchRequest.bindings do2$>, <$Binding.name$>: <$Binding.type$><$endforeach do2$>, error outError: NSErrorPointer) -> [Any]? {
-        guard let psc = managedObjectContext.persistentStoreCoordinator else { return nil }
-        let model = psc.managedObjectModel
-        let substitutionVariables : [String : Any] = [<$if FetchRequest.hasBindings$><$foreach Binding FetchRequest.bindings do2$>
-            "<$Binding.name$>": <$Binding.name$>,
-<$endforeach do2$><$else$>:<$endif$>]
-
-        guard let fetchRequest = model.fetchRequestFromTemplate(withName: "<$FetchRequest.name$>", substitutionVariables: substitutionVariables) else {
-        	assert(false, "Can't find fetch request named \"<$FetchRequest.name$>\".")
-		return nil
-	}
-        var results = Array<Any>()
-        do {
-             results = try managedObjectContext.fetch(fetchRequest)
-        } catch {
-          print("Error executing fetch request: \(error)")
-        }
-
-        return results
-    }
+    @NSManaged public var <$Relationship.name$>: <$Relationship.destinationEntity.managedObjectClassName$><$if Relationship.isOptional$>?<$endif$>
 <$endif$>
 <$endforeach do$>
 
 <$foreach FetchedProperty noninheritedFetchedProperties do$>
-    @NSManaged open
-    let <$FetchedProperty.name$>: [<$FetchedProperty.entity.sanitizedManagedObjectClassName$>]
+    @NSManaged open let <$FetchedProperty.name$>: [<$FetchedProperty.entity.sanitizedManagedObjectClassName$>]
 <$endforeach do$>
-}
-
-<$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
-extension _<$sanitizedManagedObjectClassName$> {
-
-    open func add<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.union(objects<$if !Relationship.jr_isOrdered$> as Set<NSObject><$endif$>)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
-
-    open func remove<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.minus(objects<$if !Relationship.jr_isOrdered$> as Set<NSObject><$endif$>)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
-
-    open func add<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.add(value)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
-
-    open func remove<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.remove(value)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
 
 }
-<$endif$><$endforeach do$>


### PR DESCRIPTION
### Summary of Changes

This is extensive rewrite of the Swift templates. Highlights:

- removed `_ModelClass` subclass, no need for it in Swift
- there‘s only one `ModelClass` in human template + extension in machine template
- [proper support](http://aplus.rs/2017/handling-core-data-optional-scalar-attributes/) for Optional attributes with "Use Scalar Type"
- replaced usage of `NSSet` with proper `Set<ModelClass>`
- changed `func entityName()` to `var entityName`
- removed `add*` and `remove*` methods since they are not needed when Set<XX> is present
- replaced Attributes / Relationships enums with `struct` with `static let` String constants, to avoid use of `.rawValue` all over the code
- moved those structs into the extension, so they can be properly "namespaced", as `ModelClass.Attributes.xxx`

### Addresses

None. Simply an improvement over existing stuff.
