### PR TITLE
Expose information when custom type is set through userInfo

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -32,12 +32,14 @@
 @interface NSAttributeDescription (typing)
 - (BOOL)hasScalarAttributeType;
 - (BOOL)usesScalarAttributeType;
+- (BOOL)usesCustomScalarAttributeType;
 - (NSString*)scalarAttributeType;
 - (NSString*)scalarAccessorMethodName;
 - (NSString*)scalarFactoryMethodName;
 - (BOOL)hasDefinedAttributeType;
 - (NSArray*)objectAttributeTransformableProtocols;
 - (BOOL)hasAttributeTransformableProtocols;
+- (BOOL)usesCustomObjectAttributeType;
 - (NSString*)objectAttributeClassName;
 - (NSString*)objectAttributeType;
 - (BOOL)hasTransformableAttributeType;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -443,6 +443,11 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
     }
 }
 
+- (BOOL)usesCustomScalarAttributeType {
+    NSString *attributeValueScalarType = [[self userInfo] objectForKey:kAttributeValueScalarTypeKey];
+    return (attributeValueScalarType != nil);
+}
+
 - (NSString*)scalarAttributeType {
     BOOL isUnsigned = [self isUnsigned];
 
@@ -584,6 +589,12 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
 - (BOOL)hasAttributeTransformableProtocols {
     return [self hasTransformableAttributeType] && [[self userInfo] objectForKey:@"attributeTransformableProtocols"];
 }
+
+- (BOOL)usesCustomObjectAttributeType {
+    NSString *attributeValueClassName = [[self userInfo] objectForKey:@"attributeValueClassName"];
+    return (attributeValueClassName != nil);
+}
+
 - (NSString*)objectAttributeType {
     NSString *result = [self objectAttributeClassName];
     if ([result isEqualToString:@"Class"]) {


### PR DESCRIPTION
### Summary of Changes

Expose information when custom type is set through userInfo. This allows you to write custom getter/setter for these attributes in Swift.

Please see [my blog post](http://aplus.rs/2017/custom-typed-coredata-attributes/) for deeper explanation.

### Addresses

None.