### PR TITLE
Add support for URI and UUID attribute types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode9
 #xcode_project: mogenerator.xcodeproj
 #xcode_scheme: mogenerator
 script: cd test && rake

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -558,8 +558,23 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
             result = gSwift ? @"AnyObject" : @"NSObject";
         }
     } else {
-        result = [self attributeValueClassName];
+        // Forcibly generate the correct class name in case we are
+        // running on macOS < 10.13
+        switch ([self attributeType]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+            case NSURIAttributeType:
+                result = @"NSURL";
+                break;
+            case NSUUIDAttributeType:
+                result = @"NSUUID";
+                break;
+#pragma clang diagnostic pop
+            default:
+                result = [self attributeValueClassName];
+        }
     }
+    
     if (gSwift) {
         if ([result isEqualToString:@"NSString"]) {
             result = @"String";
@@ -567,6 +582,10 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
             result = @"Date";
         } else if ([result isEqualToString:@"NSData"]) {
             result = @"Data";
+        } else if ([result isEqualToString:@"NSURL"]) {
+            result = @"URL";
+        } else if ([result isEqualToString:@"NSUUID"]) {
+            result = @"UUID";
         }
     }
     return result;

--- a/momcom/NSAttributeDescription+momcom.m
+++ b/momcom/NSAttributeDescription+momcom.m
@@ -30,6 +30,11 @@ const NSString *const kUsesScalarAttributeType = @"mogenerator.usesScalarAttribu
                               @"Float"          : @(NSFloatAttributeType),
                               @"String"         : @(NSStringAttributeType),
                               @"Transformable"  : @(NSTransformableAttributeType),
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+                              @"URI"            : @(NSURIAttributeType),
+                              @"UUID"           : @(NSUUIDAttributeType),
+#pragma clang diagnostic pop
                               };
     });
 }

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -12,7 +12,7 @@ end
 #==============================
 # Variables
 #==============================
-OSX_SDK=run_or_die('xcrun --sdk macosx --show-sdk-path').chomp()
+OSX_SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk"
 OSX_VERSION="10.10"
 LINKED_FRAMEWORKS="-framework Foundation -framework AppKit -framework CoreData"
 

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -12,7 +12,7 @@ end
 #==============================
 # Variables
 #==============================
-OSX_SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk"
+OSX_SDK=run_or_die('xcrun --sdk macosx --show-sdk-path').chomp()
 OSX_VERSION="10.10"
 LINKED_FRAMEWORKS="-framework Foundation -framework AppKit -framework CoreData"
 


### PR DESCRIPTION
### Summary of Changes

This adds support for generating accessors for `NSURIAttributeType` and `NSUUIDAttributeType` attributes, which were introduced in iOS 11 and macOS 10.13.

With the introduction of this change, the mogenerator binary must be built using Xcode 9.