### PR TITLE
Fixed invalid call of `NSManagedObject.fetchRequest()`

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -47,11 +47,7 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
 
     @nonobjc
     open class func fetchRequest() -> NSFetchRequest<<$sanitizedManagedObjectClassName$>> {
-        if #available(iOS 10.0, tvOS 10.0, watchOS 3.0, macOS 10.12, *) {
-            return NSManagedObject.fetchRequest() as! NSFetchRequest<<$sanitizedManagedObjectClassName$>>
-        } else {
-            return NSFetchRequest(entityName: self.entityName())
-        }
+        return NSFetchRequest(entityName: self.entityName())
     }
 
     // MARK: - Life cycle methods


### PR DESCRIPTION
Calling `NSManagedObject.fetchRequest()` is invalid:

> This method is only legal to call on **subclasses of `NSManagedObject`** that represent a single entity in the model.

https://developer.apple.com/documentation/coredata/nsmanagedobject/1640605-fetchrequest

The proper way is to call good old `NSFetchRequest(entityName: self.entityName())`, which gets bridged to the specialized `NSFetchRequest<…>`.