### PR TITLE
Add parameter to ignore entities

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -67,6 +67,7 @@
     NSString              *baseClass;
     NSString              *baseClassImport;
     NSString              *baseClassForce;
+    NSString              *ignoredEntities;
     NSString              *includem;
     NSString              *includeh;
     NSString              *templatePath;

--- a/mogenerator.h
+++ b/mogenerator.h
@@ -17,6 +17,11 @@
 - (NSArray*)entitiesWithACustomSubclassInConfiguration:(NSString*)configuration_ verbose:(BOOL)verbose_;
 @end
 
+@interface NSEntityDescription (userInfo)
+/// @return Whether or not the entity should be ignored during code generation
+- (BOOL)isIgnored;
+@end
+
 @interface NSEntityDescription (customBaseClass)
 - (BOOL)hasCustomClass;
 - (BOOL)hasSuperentity;
@@ -27,7 +32,6 @@
 - (NSString*)additionalHeaderFileName;
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_;
 - (NSArray*)prettyFetchRequests;
-- (BOOL)isIgnored;
 @end
 
 @interface NSAttributeDescription (typing)

--- a/mogenerator.h
+++ b/mogenerator.h
@@ -27,6 +27,7 @@
 - (NSString*)additionalHeaderFileName;
 - (void)_processPredicate:(NSPredicate*)predicate_ bindings:(NSMutableArray*)bindings_;
 - (NSArray*)prettyFetchRequests;
+- (BOOL)isIgnored;
 @end
 
 @interface NSAttributeDescription (typing)
@@ -67,7 +68,6 @@
     NSString              *baseClass;
     NSString              *baseClassImport;
     NSString              *baseClassForce;
-    NSString              *ignoredEntities;
     NSString              *includem;
     NSString              *includeh;
     NSString              *templatePath;

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -136,6 +136,15 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
 }
 @end
 
+@implementation NSEntityDescription (userInfo)
+- (BOOL)isIgnored {
+    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:kIgnored];
+    if (readonlyUserinfoValue != nil) {
+        return YES;
+    }
+    return NO;
+}
+@end
 
 @implementation NSEntityDescription (customBaseClass)
 - (BOOL)hasCustomBaseCaseImport {
@@ -420,13 +429,6 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
     return result;
 }
 
-- (BOOL)isIgnored {
-    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:kIgnored];
-    if (readonlyUserinfoValue != nil) {
-        return YES;
-    }
-    return NO;
-}
 @end
 
 @implementation NSAttributeDescription (typing)

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -19,6 +19,7 @@ static const NSString *const kAdditionalHeaderFileNameKey = @"additionalHeaderFi
 static const NSString *const kAdditionalImportsKey = @"additionalImports";
 static const NSString *const kCustomBaseClass = @"mogenerator.customBaseClass";
 static const NSString *const kReadOnly = @"mogenerator.readonly";
+static const NSString *const kIgnored = @"mogenerator.ignore";
 
 @interface NSEntityDescription (fetchedPropertiesAdditions)
 - (NSDictionary*)fetchedPropertiesByName;
@@ -418,6 +419,14 @@ static const NSString *const kReadOnly = @"mogenerator.readonly";
     }
     return result;
 }
+
+- (BOOL)isIgnored {
+    NSString *readonlyUserinfoValue = [[self userInfo] objectForKey:kIgnored];
+    if (readonlyUserinfoValue != nil) {
+        return YES;
+    }
+    return NO;
+}
 @end
 
 @implementation NSAttributeDescription (typing)
@@ -796,7 +805,6 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         {@"base-class",         0,     DDGetoptRequiredArgument},
         {@"base-class-import",  0,     DDGetoptRequiredArgument},
         {@"base-class-force",   0,     DDGetoptRequiredArgument},
-        {@"ignored-entities",   0,     DDGetoptRequiredArgument},
         // For compatibility:
         {@"baseClass",          0,     DDGetoptRequiredArgument},
         {@"includem",           0,     DDGetoptRequiredArgument},
@@ -851,7 +859,6 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
            "--base-class-force CLASS  Same as --base-class except will force all entities to\n"
            "                          have the specified base class. Even if a super entity\n"
            "                          exists\n"
-           "--ignored-entities LIST   Comma separated list of of entity names. Entities will be ignored when generating classes\n"
            "--includem FILE           Generate aggregate include file for .m files for both\n"
            "                          human and machine generated source files\n"
            "--includeh FILE           Generate aggregate include file for .h files for human\n"
@@ -1048,11 +1055,6 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
     }
 }
 
-- (BOOL)isIgnoredEntity:(NSString *)entityName {
-    NSArray<NSString *> *entities = [ignoredEntities componentsSeparatedByString:@","];
-    return [entities containsObject:entityName] || [entities containsObject:[NSString stringWithFormat:@"_%@", entityName]];
-}
-
 - (int)application:(DDCliApplication*)app runWithArguments:(NSArray*)arguments {
     if (_help) {
         [self printUsage];
@@ -1199,7 +1201,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         NSArray *entitiesWithCustomSubclass = [model entitiesWithACustomSubclassInConfiguration:configuration verbose:YES];
         for (NSEntityDescription *entity in entitiesWithCustomSubclass)
         {
-            if ([self isIgnoredEntity:entity.name]) {
+            if ([entity isIgnored]) {
                 continue;
             }
             NSString *generatedMachineH = [machineH executeWithObject:entity sender:nil];

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -796,6 +796,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         {@"base-class",         0,     DDGetoptRequiredArgument},
         {@"base-class-import",  0,     DDGetoptRequiredArgument},
         {@"base-class-force",   0,     DDGetoptRequiredArgument},
+        {@"ignored-entities",   0,     DDGetoptRequiredArgument},
         // For compatibility:
         {@"baseClass",          0,     DDGetoptRequiredArgument},
         {@"includem",           0,     DDGetoptRequiredArgument},
@@ -850,6 +851,7 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
            "--base-class-force CLASS  Same as --base-class except will force all entities to\n"
            "                          have the specified base class. Even if a super entity\n"
            "                          exists\n"
+           "--ignored-entities LIST   Comma separated list of of entity names. Entities will be ignored when generating classes\n"
            "--includem FILE           Generate aggregate include file for .m files for both\n"
            "                          human and machine generated source files\n"
            "--includeh FILE           Generate aggregate include file for .h files for human\n"
@@ -1046,6 +1048,11 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
     }
 }
 
+- (BOOL)isIgnoredEntity:(NSString *)entityName {
+    NSArray<NSString *> *entities = [ignoredEntities componentsSeparatedByString:@","];
+    return [entities containsObject:entityName] || [entities containsObject:[NSString stringWithFormat:@"_%@", entityName]];
+}
+
 - (int)application:(DDCliApplication*)app runWithArguments:(NSArray*)arguments {
     if (_help) {
         [self printUsage];
@@ -1192,6 +1199,9 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         NSArray *entitiesWithCustomSubclass = [model entitiesWithACustomSubclassInConfiguration:configuration verbose:YES];
         for (NSEntityDescription *entity in entitiesWithCustomSubclass)
         {
+            if ([self isIgnoredEntity:entity.name]) {
+                continue;
+            }
             NSString *generatedMachineH = [machineH executeWithObject:entity sender:nil];
             NSString *generatedMachineM = [machineM executeWithObject:entity sender:nil];
             NSString *generatedHumanH = [humanH executeWithObject:entity sender:nil];

--- a/mogenerator.m
+++ b/mogenerator.m
@@ -428,7 +428,6 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
     }
     return result;
 }
-
 @end
 
 @implementation NSAttributeDescription (typing)

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -26,9 +26,7 @@ run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator cle
 run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator'
 
 def gen_and_compile_objc(mogenPath, extra_mogen_args, extra_llvm_args)
-  status = '*** Testing Objective-C'
-  status << ' with parameters' if extra_mogen_args.length > 0
-  puts status
+  puts = '*** Testing Objective-C'
   ENV['MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS'] = '1'
   run_or_die "#{mogenPath.gsub(/ /, '\\ ')} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
   run_or_die 'cp ./objc/Gender.* ./objc/MyBaseClass.* MOs'
@@ -62,13 +60,11 @@ task :swift do
   Rake::Task[:clean].execute
 end
 
-desc 'Generate, Compile and Run with parameters'
+desc 'Generate, Compile and test ignored entities'
 task :objc do
   Rake::Task[:clean].execute
-  gen_and_compile_objc(MOGENERATOR_PATH, '--ignored-entities Uncle,Aunt', '')
-  includes_uncle = Dir.entries('./MOs').any? do |file|
-    file.include?('Uncle') || file.include?('Aunt')
-  end
+  gen_and_compile_objc(MOGENERATOR_PATH, '', '')
+  includes_uncle = Dir.entries('./MOs').any? { |file| file.include?('Uncle') }
   raise 'Failed: Ignored entities should not be generated' if includes_uncle
   Rake::Task[:clean].execute
 end

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -26,7 +26,9 @@ run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator cle
 run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator'
 
 def gen_and_compile_objc(mogenPath, extra_mogen_args, extra_llvm_args)
-  puts "*** Testing Objective-C"
+  status = '*** Testing Objective-C'
+  status << ' with parameters' if extra_mogen_args.length > 0
+  puts status
   ENV['MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS'] = '1'
   run_or_die "#{mogenPath.gsub(/ /, '\\ ')} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
   run_or_die 'cp ./objc/Gender.* ./objc/MyBaseClass.* MOs'
@@ -60,6 +62,16 @@ task :swift do
   Rake::Task[:clean].execute
 end
 
+desc 'Generate, Compile and Run with parameters'
+task :objc do
+  Rake::Task[:clean].execute
+  gen_and_compile_objc(MOGENERATOR_PATH, '--ignored-entities Uncle,Aunt', '')
+  includes_uncle = Dir.entries('./MOs').any? do |file|
+    file.include?('Uncle') || file.include?('Aunt')
+  end
+  raise 'Failed: Ignored entities should not be generated' if includes_uncle
+  Rake::Task[:clean].execute
+end
 
 desc 'Clean output'
 task :clean do

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -26,7 +26,7 @@ run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator cle
 run_or_die 'xcodebuild -project ../mogenerator.xcodeproj -scheme mogenerator'
 
 def gen_and_compile_objc(mogenPath, extra_mogen_args, extra_llvm_args)
-  puts = '*** Testing Objective-C'
+  puts "*** Testing Objective-C"
   ENV['MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS'] = '1'
   run_or_die "#{mogenPath.gsub(/ /, '\\ ')} --model test.xcdatamodel --output MOs --baseClass MyBaseClass #{extra_mogen_args}"
   run_or_die 'cp ./objc/Gender.* ./objc/MyBaseClass.* MOs'

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -45,11 +45,17 @@ def gen_and_compile_swift(mogenPath, extra_mogen_args)
   puts run_or_die './testbin'
 end
 
+def assert_entity_user_info_respected
+  # mogenerator.ignore
+  includes_uncle = Dir.entries('./MOs').any? { |file| file.include?('Uncle') }
+  raise 'Failed: Ignored entities should not be generated' if includes_uncle
+end
 
 desc 'Generate, Compile and Run Objective-C'
 task :objc do
   Rake::Task[:clean].execute
   gen_and_compile_objc(MOGENERATOR_PATH, '', '')
+  assert_entity_user_info_respected
   Rake::Task[:clean].execute
 end
 
@@ -57,17 +63,10 @@ desc 'Generate, Compile and Run Swift'
 task :swift do
   Rake::Task[:clean].execute
   gen_and_compile_swift(MOGENERATOR_PATH, '')
+  assert_entity_user_info_respected
   Rake::Task[:clean].execute
 end
 
-desc 'Generate, Compile and test ignored entities'
-task :objc do
-  Rake::Task[:clean].execute
-  gen_and_compile_objc(MOGENERATOR_PATH, '', '')
-  includes_uncle = Dir.entries('./MOs').any? { |file| file.include?('Uncle') }
-  raise 'Failed: Ignored entities should not be generated' if includes_uncle
-  Rake::Task[:clean].execute
-end
 
 desc 'Clean output'
 task :clean do

--- a/test/test.xcdatamodel/contents
+++ b/test/test.xcdatamodel/contents
@@ -57,6 +57,9 @@
     </entity>
     <entity name="Uncle" representedClassName="UncleMO" parentEntity="Human" syncable="YES">
         <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
+        <userInfo>
+            <entry key="mogenerator.ignore" value="value"/>
+        </userInfo>
     </entity>
     <fetchRequest name="allHumans" entity="Human"/>
     <fetchRequest name="byHumanName" entity="Human" predicateString="humanName == $humanName"/>

--- a/test/test.xcdatamodel/contents
+++ b/test/test.xcdatamodel/contents
@@ -55,6 +55,9 @@
         <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Child" indexed="YES" syncable="YES"/>
         <relationship name="orderedChildren" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Child" inverseName="parent" inverseEntity="Child" indexed="YES" syncable="YES"/>
     </entity>
+    <entity name="Uncle" representedClassName="UncleMO" parentEntity="Human" syncable="YES">
+        <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <fetchRequest name="allHumans" entity="Human"/>
     <fetchRequest name="byHumanName" entity="Human" predicateString="humanName == $humanName"/>
     <fetchRequest name="byParent" entity="Child" predicateString="parent == $parent"/>
@@ -69,5 +72,6 @@
         <element name="EntityWithBaseClass" positionX="342" positionY="18" width="128" height="60"/>
         <element name="Human" positionX="169" positionY="18" width="128" height="105"/>
         <element name="Parent" positionX="34" positionY="114" width="128" height="270"/>
+        <element name="Uncle" positionX="243" positionY="-36" width="128" height="60"/>
     </elements>
 </model>


### PR DESCRIPTION
Hi @rentzsch 

Recently I have been looking into using the _Xcode_ CoreData generated NSManagedObject subclasses. The code base we are working on is kind of big and we have **plenty** of _Mogenerator_ generated classes. 

In order to slowly migrate to the Xcode generated classes we need a way to use both generators at the same time. 

Xcode already supports this by allowing to enable/disable code generation per entity. This pull request adds support for ignoring entities when generating with _Mogenerator_ (I looked a bit but couldn't find any other solution to ignore entities).

Tests passed with `MacOSX10.14.sdk` and I added another test for checking if the parameter works.

Thank you and I am looking forward to your feedback!