### PR TITLE
Fix generation mangling when model entity has current module selected for name

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -211,6 +211,15 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
         return forcedBaseClass;
     }
 }
+
+- (NSString*)sanitizedCustomSuperentity {
+    NSString *customSuperentity = [self customSuperentity];
+    if ([customSuperentity hasPrefix:@"."]) {
+        return [customSuperentity stringByReplacingOccurrencesOfString:@"." withString:@""];
+    }
+    return customSuperentity;
+}
+
 - (NSString*)forcedCustomBaseClass {
     NSString* userInfoCustomBaseClass = [[self userInfo] objectForKey:kCustomBaseClass];
     return userInfoCustomBaseClass ? userInfoCustomBaseClass : gCustomBaseClassForced;
@@ -447,6 +456,7 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
         case NSInteger16AttributeType:
         case NSInteger32AttributeType:
         case NSInteger64AttributeType:
+		case NSDecimalAttributeType:
         case NSDoubleAttributeType:
         case NSFloatAttributeType:
         case NSBooleanAttributeType:
@@ -489,6 +499,9 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
                 break;
             case NSInteger64AttributeType:
                 return gSwift ? isUnsigned ? @"UInt64" : @"Int64" : isUnsigned ? @"uint64_t" : @"int64_t";
+                break;
+            case NSDecimalAttributeType:
+                return gSwift ? @"Decimal" : @"NSDecimalNumber";
                 break;
             case NSDoubleAttributeType:
                 return gSwift ? @"Double" : @"double";
@@ -1220,6 +1233,10 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
             generatedHumanM = [generatedHumanM stringByReplacingOccurrencesOfRegex:searchPattern withString:replacementString];
 
             NSString *entityClassName = [entity managedObjectClassName];
+            if ([entityClassName.firstLetter compare:@"."] == NSOrderedSame) {
+                // If default module specified, "MyClass" -> ".MyClass" -> "_MyClass"/"__MyClass"
+                entityClassName = [entityClassName substringFromIndex:1];
+            }
             entityClassName = [entityClassName stringByReplacingOccurrencesOfString:@"." withString:@"_"];
             BOOL machineDirtied = NO;
 

--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 			);
 			name = mogenerator;
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		08FB7795FE84155DC02AAC07 /* Source */ = {
 			isa = PBXGroup;

--- a/momcom/NSEntityDescription+momcom.m
+++ b/momcom/NSEntityDescription+momcom.m
@@ -28,6 +28,9 @@
         if ([attributeName isEqualToString:@"name"]) {
             [entityDescription setName:attributeString];
         } else if ([attributeName isEqualToString:@"representedClassName"]) {
+			if ([attributeString hasPrefix:@"."]) {
+				attributeString = [attributeString substringFromIndex:1];
+			}
             [entityDescription setManagedObjectClassName:attributeString];
         } else if ([attributeName isEqualToString:@"elementID"]) {
             [entityDescription setRenamingIdentifier:attributeString];

--- a/momcom/NSEntityDescription+momcom.m
+++ b/momcom/NSEntityDescription+momcom.m
@@ -28,9 +28,9 @@
         if ([attributeName isEqualToString:@"name"]) {
             [entityDescription setName:attributeString];
         } else if ([attributeName isEqualToString:@"representedClassName"]) {
-			if ([attributeString hasPrefix:@"."]) {
-				attributeString = [attributeString substringFromIndex:1];
-			}
+            if ([attributeString hasPrefix:@"."]) {
+                attributeString = [attributeString substringFromIndex:1];
+            }
             [entityDescription setManagedObjectClassName:attributeString];
         } else if ([attributeName isEqualToString:@"elementID"]) {
             [entityDescription setRenamingIdentifier:attributeString];

--- a/momcom/NSEntityDescription+momcom.m
+++ b/momcom/NSEntityDescription+momcom.m
@@ -28,9 +28,6 @@
         if ([attributeName isEqualToString:@"name"]) {
             [entityDescription setName:attributeString];
         } else if ([attributeName isEqualToString:@"representedClassName"]) {
-            if ([attributeString hasPrefix:@"."]) {
-                attributeString = [attributeString substringFromIndex:1];
-            }
             [entityDescription setManagedObjectClassName:attributeString];
         } else if ([attributeName isEqualToString:@"elementID"]) {
             [entityDescription setRenamingIdentifier:attributeString];


### PR DESCRIPTION
### Summary of Changes

Remove the leading period from representedClassName when parsing NSEntityDescription as it signifies the user has selected the current module for scope. If this is left in the generated class names get mangled, but it is important for core data to have this information when going back and forth between a swift module and an ObjC module, such as happens when your model is in a swift framework.

### Addresses

#339
