### PR TITLE
Fixes for Swift to-many accessors, Swift mutableSets

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -194,30 +194,16 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
 
 <$foreach Relationship noninheritedRelationships do$><$if Relationship.isToMany$>
 extension _<$sanitizedManagedObjectClassName$> {
+	@NSManaged
+    open func add<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>)
 
-    open func add<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.union(objects<$if !Relationship.jr_isOrdered$> as Set<NSObject><$endif$>)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
+	@NSManaged
+    open func remove<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>)
 
-    open func remove<$Relationship.name.initialCapitalString$>(_ objects: <$Relationship.immutableCollectionClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.minus(objects<$if !Relationship.jr_isOrdered$> as Set<NSObject><$endif$>)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
+	@NSManaged
+    open func add<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>)
 
-    open func add<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.add(value)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
-
-    open func remove<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>) {
-        let mutable = self.<$Relationship.name$>.mutableCopy() as! NSMutable<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-        mutable.remove(value)
-        self.<$Relationship.name$> = mutable.copy() as! NS<$if Relationship.jr_isOrdered$>Ordered<$endif$>Set
-    }
-
+	@NSManaged
+    open func remove<$Relationship.name.initialCapitalString$>Object(_ value: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$>) 
 }
 <$endif$><$endforeach do$>

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -51,11 +51,6 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
         return NSEntityDescription.entity(forEntityName: self.entityName(), in: managedObjectContext)
     }
 
-    @nonobjc
-    open class func fetchRequest() -> NSFetchRequest<<$sanitizedManagedObjectClassName$>> {
-        return NSFetchRequest(entityName: self.entityName())
-    }
-
     // MARK: - Life cycle methods
 
     public override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {

--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -107,9 +107,15 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
     var <$Relationship.name$>: <$Relationship.immutableCollectionClassName$>
 
     open func <$Relationship.name$>Set() -> <$Relationship.mutableCollectionClassName$> {
-        return self.<$Relationship.name$>.mutableCopy() as! <$Relationship.mutableCollectionClassName$>
+        willAccessValue(forKey: "<$Relationship.name$>")
+  <$if Relationship.jr_isOrdered$>
+		let result = mutableOrderedSetValue(forKey:"<$Relationship.name$>")
+  <$else$>
+		let result = mutableSetValue(forKey:"<$Relationship.name$>")
+  <$endif$>
+		didAccessValue(forKey: "<$Relationship.name$>");
+        return result
     }
-
 <$else$>
     @NSManaged open
     var <$Relationship.name$>: <$Relationship.destinationEntity.sanitizedManagedObjectClassName$><$if Relationship.isOptional$>?<$endif$>


### PR DESCRIPTION
### Summary of Changes

Machine Swift template had several long standing issues, one of which was absolutely incorrect and some that needed updates or improvements.

Specifically, the mutable relationship accessors were not correct: they just returned a mutable copy of a set instead of returning the actual underlying mutable set provided by the APIs (and  where are correctly implemented in the Obj-C code). 

Later these same accessors were used in manually written add/removeObjects accessors, which while worked was not done using underlying collections and thus less efficient. Also, these accessors are now generated by the compiler, using `@NSManaged` attribute. See #332 .

### Addresses

#332 
