### PR TITLE
Try to fix Xcode 12 build (outputPaths from build-mogenerator-Info-plist.sh seems wrong)

### DIFF
--- a/mogenerator.xcodeproj/project.pbxproj
+++ b/mogenerator.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 				"$(SRCROOT)/templates/machine.swift.motemplate",
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/motemplate-Info.plist",
+				"$(DERIVED_FILE_DIR)/mogenerator-Info.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
When looking at Homebrew packages that no longer build correctly ( https://github.com/Homebrew/homebrew-core/issues/65000 ) I decided to take a quick look at mogenerator although I didn't know anything about the package before.

The build failure at first seemed very odd.  The final link was failing with:
```
error: Build input file cannot be found: '[...]/objroot/mogenerator.build/Release/mogenerator.build/DerivedSources/mogenerator-Info.plist' [...]
```
At first I assumed that the `build-mogenerator-Info-plist.sh` script either did not run or failed to produce the expected file.  However, after adding some more debugging statements that does not seem to be the case.  The script definitely runs and you can see the output from PlistBuddy in the build output:
```
Unrecognized Type:
File Doesn't Exist, Will Create: /tmp/mogenerator-20201222-40012-136lzn9/mogenerator-1.32/objroot/mogenerator.build/Release/mogenerator.build/DerivedSources/mogenerator-Info.plist
Initializing Plist...
```
(The first message comes from the use of the `-c "Clear"` line since `Clear` is supposed to take an argument I guess.. however that seems unrelated to the build failure)

Digging more into the `.pbxproj` file I noticed that the `outputPaths` from the `build-mogenerator-Info-plist.sh` build step seems to be wrong... perhaps just a typo.  I fixed that and the build worked.  My theory is that since `xcodebuild` wasn't seeing the proper dependency graph it maybe started the link before the plist was finished being written out?

Anyway it looks like the outputPaths were wrong and repairing that made this package build again for me.  YMMV.