### PR TITLE
Improved isUnsigned to check attribute minimum more carefully

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -442,13 +442,23 @@ static const NSString *const kIgnored = @"mogenerator.ignore";
 @implementation NSAttributeDescription (typing)
 - (BOOL)isUnsigned
 {
-    BOOL hasMin = NO;
+    BOOL isUnsigned = NO;
     for (NSPredicate *pred in [self validationPredicates]) {
-        if ([pred.predicateFormat containsString:@">= 0"]) {
-            hasMin = YES;
+        NSString* formatString = pred.predicateFormat;
+        NSRange range = [formatString rangeOfString:@"SELF >="];
+        if (range.location != NSNotFound) {
+            NSUInteger startIndex = range.location + range.length;
+            NSString *minString = [formatString substringFromIndex:startIndex];
+            NSScanner *scanner = [NSScanner scannerWithString:minString];
+            NSInteger minValue;
+            BOOL success = [scanner scanInteger:&minValue];
+            if (success && (minValue >= 0)) {
+                isUnsigned = YES;
+                break;
+            }
         }
     }
-    return hasMin;
+    return isUnsigned;
 }
 
 - (BOOL)hasScalarAttributeType {


### PR DESCRIPTION
The previous implementation checked the validation predicate for a string containing literally ">= 0".  But if an attribute's minimum was, for example, 1 instead of 0, the test would fail because the string would be ">= 1".  But when a minimum is 1 we still want to use `unsigned`, but weren't getting `unsigned` because of this.

Updated the code to instead look for the string "SELF >=" and then inspect the number that comes after (if any). Then we can in fact correctly check that the minimus is >= 0, thus allowing `unsigned` to be used in those cases too.
