### PR TITLE
Don't implement keyPathsForValuesAffectingValueForKey if it will do n…

### DIFF
--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -26,6 +26,7 @@
 	return (<$managedObjectClassName$>ID*)[super objectID];
 }
 
+<$if noninheritedAttributes.@count > 0$>
 + (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
 	<$foreach Attribute noninheritedAttributes do$><$if Attribute.hasDefinedAttributeType$><$if Attribute.hasScalarAttributeType && (Attribute.optional || !TemplateVar.scalarsWhenNonOptional)$>
@@ -37,6 +38,7 @@
 
 	return keyPaths;
 }
+<$endif$>
 
 <$foreach Attribute noninheritedAttributes do$>
 <$if Attribute.hasDefinedAttributeType$>


### PR DESCRIPTION
…othing but call super

If there are no `noninheritedAttributes` then the `for` loop will do nothing, and the whole method does nothing but call super really.

So where that's the case, just don't implement the method at all.

There are other cases where the `for` loop could end up doing nothing, this doesn't eliminate all such cases, just this one.
