### PR TITLE
Removed redundant `Value` method public declarations

### DIFF
--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -75,11 +75,8 @@ NS_ASSUME_NONNULL_BEGIN
 <$if Attribute.hasScalarAttributeType$>
 <$if Attribute.isReadonly$>
 @property (atomic, readonly) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
-- (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
 <$else$>
 @property (atomic) <$Attribute.scalarAttributeType$> <$Attribute.name$>Value;
-- (<$Attribute.scalarAttributeType$>)<$Attribute.name$>Value;
-- (void)set<$Attribute.name.initialCapitalString$>Value:(<$Attribute.scalarAttributeType$>)value_;
 <$endif$>
 <$endif$>
 <$endif$>


### PR DESCRIPTION
There are already @property declarations for these, so I'm not sure why the older manual form is necessary.

For example, for an attribute named `fooBar` this changes the end result in the .h file from:

```
@property (nonatomic, strong) NSNumber* fooBar;

@property (nonatomic) int32_t fooBarValue;
- (int32_t)fooBarValue;
- (void)setFooBarValue:(int32_t)value_;
```

to just:

```
@property (nonatomic, strong) NSNumber* fooBar;

@property (nonatomic) int32_t fooBarValue;
```
