### PR TITLE
issue #83: Added option to make Mike Ash-style classes optional

### DIFF
--- a/mogenerator.m
+++ b/mogenerator.m
@@ -1076,6 +1076,11 @@ NSString *ApplicationSupportSubdirectoryName = @"mogenerator";
         return EXIT_SUCCESS;
     }
 
+    // Default to generating Mike Ash-style classes if nothing specific was specified in the command arguments
+    NSNumber * useAshClassesObj = [templateVar objectForKey:@"include-ash-classes"];
+    BOOL useAshClasses = !useAshClassesObj || [useAshClassesObj boolValue];
+    [templateVar setObject:[NSNumber numberWithBool:useAshClasses] forKey:@"include-ash-classes"];
+    
     gSwift = _swift;
 
     if (baseClassForce) {

--- a/templates/machine.h.motemplate
+++ b/templates/machine.h.motemplate
@@ -171,6 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
 <$endforeach do$>
 @end
 
+<$if TemplateVar.include-ash-classes$>
 
 <$if noninheritedAttributes.@count > 0$>
 @interface <$managedObjectClassName$>Attributes: NSObject <$foreach Attribute noninheritedAttributes do$>
@@ -194,6 +195,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface <$managedObjectClassName$>UserInfo: NSObject <$foreach UserInfo userInfoKeyValues do$>
 + (NSString *)<$UserInfo.key$>;<$endforeach do$>
 @end
+<$endif$>
+
 <$endif$>
 
 NS_ASSUME_NONNULL_END

--- a/templates/machine.m.motemplate
+++ b/templates/machine.m.motemplate
@@ -277,6 +277,8 @@
 @end
 <$endif$><$endif$><$endforeach do$>
 
+<$if TemplateVar.include-ash-classes$>
+
 <$if noninheritedAttributes.@count > 0$>
 @implementation <$managedObjectClassName$>Attributes <$foreach Attribute noninheritedAttributes do$>
 + (NSString *)<$Attribute.name$> {
@@ -307,4 +309,6 @@
 	return @"<$UserInfo.value$>";
 }<$endforeach do$>
 @end
+<$endif$>
+
 <$endif$>


### PR DESCRIPTION
No change in behaviour by default.

But now if the command line includes `--template-var include-ash-classes=false` then these classes will not be created.

If you don't use them, this reduces code size a bit (200 KB / 0.12 % in my case) and removes things from Xcode's autocomplete that are just clutter.
