### PR TITLE
Provide option to treat all attributes as signed, never unsigned

### DIFF
--- a/mogenerator.h
+++ b/mogenerator.h
@@ -35,6 +35,7 @@
 @end
 
 @interface NSAttributeDescription (typing)
+- (BOOL)isUnsigned;
 - (BOOL)hasScalarAttributeType;
 - (BOOL)usesScalarAttributeType;
 - (BOOL)usesCustomScalarAttributeType;


### PR DESCRIPTION
Core Data in fact stores all integers as signed, always, regardless of their minimum.  That is, even if you have an int8 attribute with minimum set as zero, but try to set a value of 128 or more, that value will be treated as -1 and fail validation (as it's less than the minimum).

Thus one may want for the mogen accessors to also be always signed, regardless of their minimum, hence this new option.
